### PR TITLE
Replace date library

### DIFF
--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/css/components/calendar.less
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/css/components/calendar.less
@@ -48,6 +48,7 @@
 
     @media screen and (min-width: @breakpointMed) {
       min-height: 4rem;
+      max-height: 100px;
     }
 
     &.current-month {

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/css/components/modals.less
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/css/components/modals.less
@@ -27,6 +27,7 @@
   left: 50%;
   transform: translate(-50%, -50%);
   width: 75%;
+  max-width: 500px;
   padding: @modal-padding 0;
   padding-bottom: 0;
   background-color: #fff;

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/components/forms.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/components/forms.js
@@ -1,5 +1,4 @@
 import clsx from 'clsx';
-import { DateTime } from 'luxon';
 import { useReducer, useCallback } from 'react';
 import { formatCurrency, toCents } from '../lib/currency-helpers';
 import { recurrenceRules, DAY_OPTIONS } from '../lib/calendar-helpers';

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/index.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/index.js
@@ -10,7 +10,7 @@ import CashFlowEvent from './stores/models/cash-flow-event';
 
 configureMobX({ enforceActions: 'observed' });
 
-if ((process.env.NODE_ENV === 'production' || process.env.SERVICE_WORKER_ENABLED) && 'serviceWorker' in navigator) {
+if (process.env.SERVICE_WORKER_ENABLED && 'serviceWorker' in navigator) {
   const wb = new Workbox('/mmt-my-money-calendar/service-worker.js', { scope: '/mmt-my-money-calendar' });
 
   wb.addEventListener('activated', (evt) => {
@@ -32,7 +32,7 @@ if (process.env.NODE_ENV === 'development') {
 
   async function loadSeeders() {
     window.seed = await import(/* webpackChunkName: "seeds.js" */ './seed-data.js');
-  };
+  }
 
   window.seedTestData = async function seedTestData() {
     if (!window.seed) await loadSeeders();
@@ -47,7 +47,7 @@ if (process.env.NODE_ENV === 'development') {
 
     await window.seed.clearData();
     console.info('Cleared all data');
-  }
+  };
 }
 
 const App = () => (

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/index.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/index.js
@@ -2,7 +2,7 @@ import * as idb from 'idb';
 import { render } from 'react-dom';
 import { configure as configureMobX } from 'mobx';
 import { Workbox } from 'workbox-window';
-import { DateTime, Info } from 'luxon';
+import dayjs from 'dayjs';
 import { RRule } from 'rrule';
 import { StoreProvider } from './stores';
 import Routes from './routes';
@@ -27,8 +27,7 @@ if ((process.env.NODE_ENV === 'production' || process.env.SERVICE_WORKER_ENABLED
 if (process.env.NODE_ENV === 'development') {
   window.idb = idb;
   window.CashFlowEvent = CashFlowEvent;
-  window.DateTime = DateTime;
-  window.Info = Info;
+  window.dayjs = dayjs;
   window.RRule = RRule;
 
   async function loadSeeders() {

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/lib/calendar-helpers.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/lib/calendar-helpers.js
@@ -141,8 +141,8 @@ export const DAY_OPTIONS = {
 export const recurrenceRules = {
   weekly: {
     label: 'Weekly',
-    handler: (dtstart, byweekday = RRule.FR, options = {}) =>
-      new RRule({ freq: RRule.WEEKLY, dtstart, byweekday, ...options }),
+    handler: (dtstart, options = {}) =>
+      new RRule({ freq: RRule.WEEKLY, dtstart, ...options }),
   },
   biweekly: {
     label: 'Bi-weekly',

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/lib/calendar-helpers.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/lib/calendar-helpers.js
@@ -1,19 +1,14 @@
 import dayjs from 'dayjs';
 import yearDay from 'dayjs/plugin/dayOfYear';
 import weekOfYear from 'dayjs/plugin/weekOfYear';
-import { DateTime } from 'luxon';
+import customParseFormat from 'dayjs/plugin/customParseFormat';
 import { RRule, RRuleSet } from 'rrule';
 
 dayjs.extend(yearDay);
 dayjs.extend(weekOfYear);
+dayjs.extend(customParseFormat);
 
 export { dayjs as dayjs };
-
-/**
- * Luxon's DateTime class
- * @external DateTime
- * @see {@link https://moment.github.io/luxon/docs/class/src/datetime.js~DateTime.html|DateTime}
- */
 
 export const DAY_NAMES = [
   'Sunday',
@@ -46,27 +41,19 @@ export function numberWithOrdinal(num) {
   return num + (suffixes[(v - 20) % 10] || suffixes[v] || suffixes[0]);
 }
 
-/**
- * Ensures that the argument is returned as a DateTime
- *
- * @param {Date|DateTime} date - A Date instance or DateTime object
- * @returns {DateTime} a Luxon DateTime instance
- */
-export const toDateTime = (date) => (DateTime.isDateTime(date) ? date : DateTime.fromJSDate(date));
-
 export const toDayJS = (date) => dayjs(date);
 
 /**
  * Ensures that the argument is returned as a native JS Date object
  *
- * @param {Date|DateTime} date - A JS Date or dayjs object
+ * @param {Date|dayjs} date - A JS Date or dayjs object
  */
 export const toJSDate = (date) => (date instanceof Date ? date : date.toDate());
 
 /**
  * Get the ordinal day of the year for a date, as an integer
  *
- * @param {Date|DateTime} date - A Date or DateTime instance
+ * @param {Date|dayjs} date - A Date or dayjs instance
  * @returns {Number} an integer between 1 and 365
  */
 export const dayOfYear = (date) => toDayJS(date).dayOfYear();
@@ -96,7 +83,7 @@ export const limitMonthNumber = (num) => Math.min(Math.max(num, 0), 11);
 /**
  * Returns the number of the first day of the specified date's month, and the total number of days the month has
  *
- * @param {Date|DateTime} date - A JS Date or Luxon DateTime instance
+ * @param {Date|dayjs} date - A JS Date or dayjs instance
  * @returns {Object}
  */
 export function getMonthInfo(date = dayjs()) {
@@ -109,7 +96,7 @@ export function getMonthInfo(date = dayjs()) {
 /**
  * An object representing a week row on the calendar
  * @typedef {Object} Week
- * @property {dayjs[]} days - An array of DateTime objects, one for each day of the week
+ * @property {dayjs[]} days - An array of dayjs objects, one for each day of the week
  * @property {Number} weekNumber - The week number of the year
  */
 
@@ -120,19 +107,19 @@ export function getMonthInfo(date = dayjs()) {
  * @returns {Week[]} An array of Week objects
  */
 export function getWeekRows(date) {
-  date = toDateTime(date);
+  date = toDayJS(date);
   const rows = [];
   let numWeeks = Math.ceil(date.daysInMonth() / 7);
 
   for (let i = 0; i < numWeeks; i++) {
-    const startOfWeek = date.add(i, 'day').startOf('week');
+    const startOfWeek = date.add(i, 'week').startOf('week');
     const weekNumber = startOfWeek.week();
 
     rows.push({
       weekNumber,
       days: Array(7)
         .fill(0)
-        .map((n, i) => startOfWeek.add(n + i, 'day')),
+        .map((n, idx) => startOfWeek.add(n + idx, 'days')),
     });
   }
 

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/seed-data.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/seed-data.js
@@ -6,7 +6,7 @@ let currentDate;
 const now = dayjs().startOf('day');
 
 const randDay = (max = 30) => {
-  const date = now.add(Math.floor(Math.random() * max) + 1).toDate();
+  const date = now.add(Math.floor(Math.random() * max) + 1, 'days').toDate();
   currentDate = date;
   return date;
 };

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/seed-data.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/seed-data.js
@@ -1,11 +1,12 @@
 import CashFlowEvent from './stores/models/cash-flow-event';
-import { DateTime } from 'luxon';
+import { dayjs } from './lib/calendar-helpers';
 import { RRule } from 'rrule';
 
 let currentDate;
-const now = DateTime.local().startOf('day');
+const now = dayjs().startOf('day');
+
 const randDay = (max = 30) => {
-  const date = now.plus({ days: Math.floor(Math.random() * max) + 1 }).toJSDate();
+  const date = now.add(Math.floor(Math.random() * max) + 1).toDate();
   currentDate = date;
   return date;
 };
@@ -28,7 +29,7 @@ function seedCashFlowEvents() {
   const events = [
     {
       name: 'Starting Balance',
-      date: now.toJSDate(),
+      date: now.toDate(),
       totalCents: 50000,
       category: 'startingBalance',
     },

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/stores/cash-flow-store.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/stores/cash-flow-store.js
@@ -239,7 +239,7 @@ export default class CashFlowStore {
     if (andRecurrences && recurrences && recurrences.length) {
       for (const recurrence of recurrences) {
         // only delete future recurrences:
-        if (event.dateTime.diff(recurrence.dateTime, 'days').toObject().days > 0) continue;
+        if (recurrence.dateTime.isBefore(event.dateTime)) continue;
 
         yield recurrence.destroy();
         deletedIDs.push(recurrence.id);

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/stores/cash-flow-store.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/stores/cash-flow-store.js
@@ -2,10 +2,9 @@ import { flow, observable, computed, action } from 'mobx';
 import { asyncComputed } from 'computed-async-mobx';
 import { computedFn } from 'mobx-utils';
 import logger from '../lib/logger';
-import { toDateTime, dayOfYear } from '../lib/calendar-helpers';
+import { toDayJS } from '../lib/calendar-helpers';
 import { toMap } from '../lib/array-helpers';
 import CashFlowEvent from './models/cash-flow-event';
-import { DateTime } from 'luxon';
 
 export default class CashFlowStore {
   @observable eventsLoaded = false;
@@ -83,11 +82,11 @@ export default class CashFlowStore {
   /**
    * Get the user's available balance for the specified date
    *
-   * @param {Date|DateTime} stopDate - The date to check the balance for
+   * @param {Date|dayjs} stopDate - The date to check the balance for
    * @returns {Number} the balance in dollars
    */
   getBalanceForDate = computedFn(function getBalanceForDate(stopDate) {
-    stopDate = toDateTime(stopDate).endOf('day');
+    stopDate = toDayJS(stopDate).endOf('day');
     const stopTimestamp = stopDate.valueOf();
 
     if (!this.events.length) return totalInCents;
@@ -106,7 +105,7 @@ export default class CashFlowStore {
   /**
    * Get the total amount of money received or spent for a particular day
    *
-   * @param {Date|DateTime} date - The date
+   * @param {Date|dayjs} date - The date
    * @returns {Number} The amount of money for that day received or spent
    */
   getTotalForDate = computedFn(function getTotalForDate(date) {
@@ -118,7 +117,7 @@ export default class CashFlowStore {
   /**
    * Determines whether or not the given date has any income events
    *
-   * @param {Date|DateTime} date - The date to check
+   * @param {Date|dayjs} date - The date to check
    * @returns {Boolean}
    */
   dateHasIncome(date) {
@@ -132,7 +131,7 @@ export default class CashFlowStore {
   /**
    * Determines whether or not the given date has any expense events
    *
-   * @param {Date|DateTime} date - The date to check
+   * @param {Date|dayjs} date - The date to check
    * @returns {Boolean}
    */
   dateHasExpenses(date) {
@@ -146,7 +145,7 @@ export default class CashFlowStore {
   /**
    * Determines whether or not a given date has any events
    *
-   * @param {Date|DateTime} date A JS date or Luxon DateTime object
+   * @param {Date|dayjs} date A JS date or dayjs object
    * @returns {boolean}
    */
   dateHasEvents(date) {
@@ -156,11 +155,11 @@ export default class CashFlowStore {
   /**
    * Returns all cash flow events for the given date
    *
-   * @param {Date|DateTime} date - The date to check
+   * @param {Date|dayjs} date - The date to check
    * @returns {CashFlowEvent[]|undefined}
    */
   getEventsForDate(date) {
-    date = toDateTime(date);
+    date = toDayJS(date);
     return this.eventsByDate.get(date.startOf('day').valueOf());
   }
 
@@ -193,7 +192,7 @@ export default class CashFlowStore {
    *
    * @param {Object} params - Event properties
    * @param {String} params.name - The event name
-   * @param {Date|DateTime} params.date - The event date
+   * @param {Date|dayjs} params.date - The event date
    * @param {String} params.category - The category name
    * @param {String} [params.subcategory] - The subcategory name
    * @param {Number} totalCents - The transaction amount, in cents

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/stores/models/cash-flow-event.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/stores/models/cash-flow-event.js
@@ -254,7 +254,7 @@ export default class CashFlowEvent {
           .endOf('day')
           .toDate()
       )
-      .map(dayjs);
+      .map((date) => dayjs(date));
   }
 
   @computed get dateTime() {

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/stores/models/cash-flow-event.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/stores/models/cash-flow-event.js
@@ -1,7 +1,7 @@
 import { observable, computed, action } from 'mobx';
 import { rrulestr } from 'rrule';
 import * as yup from 'yup';
-import { DateTime } from 'luxon';
+import { dayjs } from '../../lib/calendar-helpers';
 import EventEmitter from 'eventemitter3';
 import { asyncComputed } from 'computed-async-mobx';
 import logger from '../../lib/logger';
@@ -25,7 +25,7 @@ export default class CashFlowEvent {
   @observable payday1 = 15;
   @observable payday2 = 30;
 
-  static MIN_DATE = DateTime.fromFormat('1970-01-01', 'y-MM-dd');
+  static MIN_DATE = dayjs(0);
 
   static eventEmitter = new EventEmitter();
 
@@ -244,21 +244,21 @@ export default class CashFlowEvent {
   }
 
   @computed get recurrenceDates() {
-    const now = DateTime.local();
+    const now = dayjs();
 
     return this.recurrenceRule
       .between(
-        this.dateTime.startOf('day').toJSDate(),
+        this.dateTime.startOf('day').toDate(),
         now
-          .plus({ months: this.constructor.recurrenceMonths })
+          .add(this.constructor.recurrenceMonths, 'months')
           .endOf('day')
-          .toJSDate()
+          .toDate()
       )
-      .map(DateTime.fromJSDate);
+      .map(dayjs);
   }
 
   @computed get dateTime() {
-    return DateTime.fromJSDate(this.date).startOf('day');
+    return dayjs(this.date).startOf('day');
   }
 
   set dateTime(dateTime) {
@@ -266,23 +266,23 @@ export default class CashFlowEvent {
       return;
     }
 
-    this.date = dateTime.startOf('day').toJSDate();
+    this.date = dateTime.startOf('day').toDate();
   }
 
   @computed get createdAtDateTime() {
-    return DateTime.fromJSDate(this.createdAt);
+    return dayjs(this.createdAt);
   }
 
   set createdAtDateTime(value) {
-    this.createdAt = value.toJSDate();
+    this.createdAt = value.toDate();
   }
 
   @computed get updatedAtDateTime() {
-    return DateTime.fromJSDate(this.updatedAt);
+    return dayjs(this.updatedAt);
   }
 
   set updatedAtDateTime(value) {
-    this.updatedAt = value.toJSDate();
+    this.updatedAt = value.toDate();
   }
 
   @computed get total() {
@@ -408,7 +408,7 @@ export default class CashFlowEvent {
       name: this.name,
       totalCents: Math.abs(this.totalCents),
       category: this.category,
-      dateTime: this.dateTime && !this.dateTime.invalidReason ? this.dateTime.toFormat('yyyy-MM-dd') : null,
+      dateTime: this.dateTime && this.dateTime.isValid() ? this.dateTime.format('YYYY-MM-DD') : null,
       recurs: this.recurs,
       recurrenceType: this.recurrenceType,
       payday1: this.payday1,
@@ -420,12 +420,10 @@ export default class CashFlowEvent {
     const id = this.isRecurrence ? this.originalEventID : this.id;
     const { store } = await this.transaction();
     const index = store.index('originalEventID_date');
-    const lowerBound = [id, this.constructor.MIN_DATE.toJSDate()];
+    const lowerBound = [id, this.constructor.MIN_DATE.toDate()];
     const upperBound = [
       id,
-      DateTime.local()
-        .plus({ months: 3 })
-        .toJSDate(),
+      dayjs().add(3, 'months').toDate(),
     ];
     const range = IDBKeyRange.bound(lowerBound, upperBound);
     let cursor = await index.openCursor(range, 'next');

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/stores/ui-store.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/stores/ui-store.js
@@ -1,7 +1,6 @@
 import { observable, computed, action } from 'mobx';
 import logger from '../lib/logger';
-import { DateTime } from 'luxon';
-import { limitMonthNumber, getWeekRows, toDateTime } from '../lib/calendar-helpers';
+import { getWeekRows, toDayJS, dayjs } from '../lib/calendar-helpers';
 
 export default class UIStore {
   @observable navOpen = false;
@@ -12,7 +11,7 @@ export default class UIStore {
   @observable prevStepPath;
   @observable progress = 0;
   @observable error;
-  @observable currentMonth = DateTime.local().startOf('month');
+  @observable currentMonth = dayjs().startOf('month');
   @observable selectedDate;
   @observable selectedCategory = '';
   @observable showBottomNav = true;
@@ -58,19 +57,19 @@ export default class UIStore {
   }
 
   @action setCurrentMonth(month) {
-    this.currentMonth = toDateTime(month);
+    this.currentMonth = toDayJS(month);
   }
 
   @action nextMonth() {
-    this.currentMonth = this.currentMonth.plus({ months: 1 });
+    this.currentMonth = this.currentMonth.add(1, 'month');
   }
 
   @action prevMonth() {
-    this.currentMonth = this.currentMonth.minus({ months: 1 });
+    this.currentMonth = this.currentMonth.subtract(1, 'month');
   }
 
   @action setSelectedDate(date) {
-    this.selectedDate = toDateTime(date).startOf('day');
+    this.selectedDate = toDayJS(date).startOf('day');
   }
 
   @action clearSelectedDate() {
@@ -78,7 +77,7 @@ export default class UIStore {
   }
 
   @action gotoDate(date) {
-    date = toDateTime(date);
+    date = toDayJS(date);
     this.currentMonth = date.startOf('month');
     this.selectedDate = date.startOf('day');
   }

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/calendar/add/debug.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/calendar/add/debug.js
@@ -1,10 +1,9 @@
-import clsx from 'clsx';
 import { useMemo } from 'react';
 import { observer } from 'mobx-react';
 import { useFormik } from 'formik';
 import { useHistory } from 'react-router-dom';
 import * as yup from 'yup';
-import { DateTime } from 'luxon';
+import { dayjs } from '../../../lib/calendar-helpers';
 import { useStore } from '../../../stores';
 import { Categories } from '../../../stores/models/categories';
 import Button, { ButtonLink } from '../../../components/button';
@@ -31,7 +30,7 @@ function Debug() {
       totalCents: 0,
       category: undefined,
       eventType: undefined,
-      dateTime: uiStore.selectedDate ? uiStore.selectedDate.toFormat('yyyy-MM-dd') : '',
+      dateTime: uiStore.selectedDate ? uiStore.selectedDate.format('YYYY-MM-DD') : '',
       recurs: false,
       recurrenceRule: undefined,
       payday1: 15,
@@ -63,13 +62,13 @@ function Debug() {
       if (values.eventType === 'expense') values.totalCents = -values.totalCents;
 
       values.totalCents = parseInt(values.totalCents, 10);
-      values.dateTime = DateTime.fromFormat(values.dateTime, 'yyyy-MM-dd');
+      values.dateTime = dayjs(values.dateTime, 'YYYY-MM-DD');
 
       if (values.recurs) {
         const { handler } = recurrenceRules[values.recurrenceRule];
         values.recurrenceRule = values.recurrenceRule === 'semimonthly'
-          ? handler(values.dateTime.toJSDate(), values.payday1, values.payday2)
-          : handler(values.dateTime.toJSDate());
+          ? handler(values.dateTime.toDate(), values.payday1, values.payday2)
+          : handler(values.dateTime.toDate());
       }
 
       try {

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/calendar/add/form.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/calendar/add/form.js
@@ -3,13 +3,11 @@ import { useMemo, useCallback } from 'react';
 import { Formik } from 'formik';
 import { useParams, useHistory, Redirect, withRouter } from 'react-router-dom';
 import * as yup from 'yup';
-import { DateTime } from 'luxon';
-import dotProp from 'dot-prop';
 import { useStore } from '../../../stores';
 import { Categories } from '../../../stores/models/categories';
 import Button, { ButtonLink, BackButton } from '../../../components/button';
 import { TextField, DateField, Checkbox, CurrencyField, RadioButton, SelectField } from '../../../components/forms';
-import { recurrenceRules, numberWithOrdinal } from '../../../lib/calendar-helpers';
+import { recurrenceRules, numberWithOrdinal, dayjs } from '../../../lib/calendar-helpers';
 import { range } from '../../../lib/array-helpers';
 import { pluck } from '../../../lib/object-helpers';
 import { useScrollToTop } from '../../../components/scroll-to-top';
@@ -120,7 +118,7 @@ function Form() {
           logger.debug('Category %s', categoryPath);
 
           values.totalCents = Number.parseInt(values.totalCents, 10);
-          values.dateTime = DateTime.fromFormat(values.dateTime, 'yyyy-MM-dd');
+          values.dateTime = dayjs(values.dateTime, 'YYYY-MM-DD');
 
           if (eventType === 'expense') values.totalCents = -values.totalCents;
 
@@ -128,8 +126,8 @@ function Form() {
             const { handler } = recurrenceRules[values.recurrenceType];
             values.recurrenceRule =
               values.recurrenceType === 'semimonthly'
-                ? handler(values.dateTime.toJSDate(), values.payday1, values.payday2)
-                : handler(values.dateTime.toJSDate());
+                ? handler(values.dateTime.toDate(), values.payday1, values.payday2)
+                : handler(values.dateTime.toDate());
           }
 
           try {

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/calendar/index/day.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/calendar/index/day.js
@@ -36,8 +36,8 @@ function Day({ day, dateFormat = 'D' }) {
   );
 
   const emptyTile = useCallback(
-    () => (
-      <div className={clsx(classes)} role="button" onClick={handleClick}>
+    (klass) => (
+      <div className={clsx(klass)} role="button" onClick={handleClick}>
         <div className="calendar__day-number">{dateString}</div>
         <div className="calendar__day-symbols" />
       </div>
@@ -45,7 +45,7 @@ function Day({ day, dateFormat = 'D' }) {
     [dateString]
   );
 
-  if (!eventStore.events.length) return emptyTile();
+  if (!eventStore.events.length) return emptyTile(classes);
 
   const balance = eventStore.getBalanceForDate(day);
 

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/calendar/index/day.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/calendar/index/day.js
@@ -17,16 +17,10 @@ const Icon = ({ icon, size, style = {}, ...props }) => {
 function Day({ day, dateFormat = 'D' }) {
   const { uiStore, eventStore } = useStore();
 
-  const isToday = useMemo(() => day.dayOfYear() === dayjs().dayOfYear(), [day]);
-  const isSelected = useMemo(() => uiStore.selectedDate && day.isSame(uiStore.selectedDate, 'day'), [
-    day,
-    uiStore.selectedDate,
-  ]);
-  const isCurrentMonth = useMemo(
-    () => day.isSame(uiStore.currentMonth, 'month') && day.isSame(uiStore.currentMonth, 'year'),
-    [day, uiStore.currentMonth]
-  );
-  const dateString = useMemo(() => day.format(dateFormat), [day, dateFormat]);
+  const isToday = day.dayOfYear() === dayjs().dayOfYear();
+  const isSelected = uiStore.selectedDate && day.isSame(uiStore.selectedDate, 'day');
+  const isCurrentMonth = day.isSame(uiStore.currentMonth, 'month') && day.isSame(uiStore.currentMonth, 'year');
+  const dateString = day.format(dateFormat);
 
   const classes = ['calendar__day', isToday && 'today', isSelected && 'selected', isCurrentMonth && 'current-month'];
 

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/calendar/index/day.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/calendar/index/day.js
@@ -1,12 +1,8 @@
 import clsx from 'clsx';
 import { useMemo, useCallback } from 'react';
 import { observer } from 'mobx-react';
-import { DateTime } from 'luxon';
 import { useStore } from '../../../stores';
-import { compact } from '../../../lib/array-helpers';
-
-import add from '@cfpb/cfpb-icons/src/icons/add.svg';
-import subtract from '@cfpb/cfpb-icons/src/icons/subtract.svg';
+import { dayjs } from '../../../lib/calendar-helpers';
 
 const Icon = ({ icon, size, style = {}, ...props }) => {
   const styles = {
@@ -18,19 +14,19 @@ const Icon = ({ icon, size, style = {}, ...props }) => {
   return <span className="calendar__day-icon" style={styles} dangerouslySetInnerHTML={{ __html: icon }} {...props} />;
 };
 
-function Day({ day, dateFormat = 'd' }) {
+function Day({ day, dateFormat = 'D' }) {
   const { uiStore, eventStore } = useStore();
 
-  const isToday = useMemo(() => day.get('ordinal') === DateTime.local().get('ordinal'), [day]);
-  const isSelected = useMemo(() => uiStore.selectedDate && day.hasSame(uiStore.selectedDate, 'day'), [
+  const isToday = useMemo(() => day.dayOfYear() === dayjs().dayOfYear(), [day]);
+  const isSelected = useMemo(() => uiStore.selectedDate && day.isSame(uiStore.selectedDate, 'day'), [
     day,
     uiStore.selectedDate,
   ]);
   const isCurrentMonth = useMemo(
-    () => day.hasSame(uiStore.currentMonth, 'month') && day.hasSame(uiStore.currentMonth, 'year'),
+    () => day.isSame(uiStore.currentMonth, 'month') && day.isSame(uiStore.currentMonth, 'year'),
     [day, uiStore.currentMonth]
   );
-  const dateString = useMemo(() => day.toFormat(dateFormat), [day, dateFormat]);
+  const dateString = useMemo(() => day.format(dateFormat), [day, dateFormat]);
 
   const classes = ['calendar__day', isToday && 'today', isSelected && 'selected', isCurrentMonth && 'current-month'];
 
@@ -38,7 +34,7 @@ function Day({ day, dateFormat = 'd' }) {
     (evt) => {
       evt.preventDefault();
 
-      uiStore.selectedDate && day.equals(uiStore.selectedDate)
+      uiStore.selectedDate && day.isSame(uiStore.selectedDate)
         ? uiStore.clearSelectedDate()
         : uiStore.setSelectedDate(day);
     },
@@ -52,7 +48,7 @@ function Day({ day, dateFormat = 'd' }) {
         <div className="calendar__day-symbols" />
       </div>
     ),
-    []
+    [dateString]
   );
 
   if (!eventStore.events.length) return emptyTile();
@@ -69,8 +65,8 @@ function Day({ day, dateFormat = 'd' }) {
   return (
     <div className={clsx(classes)} role="button" onClick={handleClick}>
       <div className="calendar__day-number">
-        <time dateTime={day.toFormat('y-MM-dd')} className="calendar__day-datetime">
-          {day.toFormat(dateFormat)}
+        <time dateTime={day.format('YYYY-MM-DD')} className="calendar__day-datetime">
+          {day.format(dateFormat)}
         </time>
       </div>
       {symbol}

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/calendar/index/details.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/calendar/index/details.js
@@ -47,7 +47,7 @@ function Details() {
 
   useLockBodyScroll(modalOpen);
 
-  const title = uiStore.selectedDate ? uiStore.selectedDate.toFormat('DDD') : uiStore.currentMonth.toFormat('MMMM, y');
+  const title = uiStore.selectedDate ? uiStore.selectedDate.format('MMMM D, YYYY') : uiStore.currentMonth.format('MMMM YYYY');
   const events = uiStore.selectedDate
     ? eventStore.eventsByDate.get(uiStore.selectedDate.startOf('day').valueOf())
     : eventStore.eventsByMonth.get(uiStore.currentMonth.startOf('month').valueOf());
@@ -63,7 +63,7 @@ function Details() {
         {events &&
           events.map((e) => (
             <li className="calendar-details__event" key={e.id} role="button" onClick={editEvent(e.id)}>
-              <div className="calendar-details__event-date">{e.dateTime.toFormat('D')}</div>
+              <div className="calendar-details__event-date">{e.dateTime.format('M/D/YYYY')}</div>
               <div className="calendar-details__event-name">{e.name}</div>
               <div className="calendar-details__event-total">{formatCurrency(e.total)}</div>
               <button className="calendar-details__event-delete" onClick={confirmDelete(e)}>

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/calendar/index/index.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/calendar/index/index.js
@@ -1,6 +1,5 @@
 import { useEffect } from 'react';
 import { useLocation, useParams } from 'react-router-dom';
-import { DateTime } from 'luxon';
 import { observer } from 'mobx-react';
 import { useStore } from '../../../stores';
 import { useClickHandler, useClickConfirm } from '../../../lib/hooks';
@@ -8,11 +7,10 @@ import Day from './day';
 import Details from './details';
 import Button, { ButtonLink } from '../../../components/button';
 import { useScrollToTop } from '../../../components/scroll-to-top';
-import { DAY_LABELS } from '../../../lib/calendar-helpers';
+import { DAY_LABELS, dayjs } from '../../../lib/calendar-helpers';
 
 import arrowRight from '@cfpb/cfpb-icons/src/icons/arrow-right.svg';
 import arrowLeft from '@cfpb/cfpb-icons/src/icons/arrow-left.svg';
-import addRound from '@cfpb/cfpb-icons/src/icons/add-round.svg';
 
 const ifDevelopment = (fn) => {
   if (process.env.NODE_ENV !== 'development') return null;
@@ -22,7 +20,7 @@ const ifDevelopment = (fn) => {
 const CalendarWeekRow = ({ days }) => (
   <div className="calendar__row">
     {days.map((day) => (
-      <Day day={day} key={`day-${day.toFormat('ooo')}`} />
+      <Day day={day} key={`day-${day.dayOfYear()}`} />
     ))}
   </div>
 );
@@ -34,7 +32,7 @@ function Calendar() {
 
   const nextMonth = useClickHandler(() => uiStore.nextMonth(), []);
   const prevMonth = useClickHandler(() => uiStore.prevMonth(), []);
-  const gotoToday = useClickHandler(() => uiStore.gotoDate(DateTime.local()), []);
+  const gotoToday = useClickHandler(() => uiStore.gotoDate(dayjs()), []);
 
   const loadSeedData = useClickHandler(async () => {
     await window.seedTestData();
@@ -50,7 +48,7 @@ function Calendar() {
 
   useEffect(() => {
     uiStore.setPageTitle('myMoney Calendar');
-    uiStore.setSubtitle(uiStore.currentMonth.toFormat('MMMM, y'));
+    uiStore.setSubtitle(uiStore.currentMonth.format('MMMM, YYYY'));
   }, [location, params, uiStore.currentMonth]);
 
   const seedButton = ifDevelopment(() => (

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/package.json
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/package.json
@@ -20,6 +20,7 @@
     "copy-webpack-plugin": "5.1.1",
     "core-js": "3",
     "css-loader": "3.4.2",
+    "dayjs": "1.8.21",
     "dot-prop": "5.2.0",
     "eventemitter3": "4.0.0",
     "file-loader": "5.0.2",

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/package.json
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/package.json
@@ -27,7 +27,6 @@
     "formik": "2.1.3",
     "idb": "5.0.0",
     "less-loader": "5.0.0",
-    "luxon": "1.21.3",
     "mini-css-extract-plugin": "0.9.0",
     "mobx": "5.15.2",
     "mobx-react": "6.1.5",

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/yarn.lock
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/yarn.lock
@@ -1560,6 +1560,11 @@ cyclist@^1.0.1:
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"
   integrity sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=
 
+dayjs@1.8.21:
+  version "1.8.21"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.8.21.tgz#98299185b72b9b679f31c7ed987b63923c961552"
+  integrity sha512-1kbWK0hziklUHkGgiKr7xm59KwAg/K3Tp7H/8X+f58DnNCwY3pKYjOCJpIlVs125FRBukGVZdKZojC073D0IeQ==
+
 debug@2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/yarn.lock
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/yarn.lock
@@ -2503,11 +2503,6 @@ lru-cache@^5.1.1:
   dependencies:
     yallist "^3.0.2"
 
-luxon@1.21.3:
-  version "1.21.3"
-  resolved "https://registry.yarnpkg.com/luxon/-/luxon-1.21.3.tgz#f1d5c2a7e855d039836cf4954f883ecac8fc4727"
-  integrity sha512-lLRwNcNnkZLuv13A1FUuZRZmTWF7ro2ricYvb0L9cvBYHPvZhQdKwrYnZzi103D2XKmlVmxWpdn2wfIiOt2YEw==
-
 luxon@^1.21.3:
   version "1.22.0"
   resolved "https://registry.yarnpkg.com/luxon/-/luxon-1.22.0.tgz#639525c7c69e594953c7b142794466b8ea85b868"


### PR DESCRIPTION
This PR addresses a bug I noticed a couple weeks ago. Luxon, the date library I was using, does not respect locale settings and always wants the first day of the week to be Monday. For most countries besides the US, that works fine, but it was causing my US-friendly calendar with weeks beginning on Sunday to report the wrong weekday for all of its dates.

I ended up needing to rip out Luxon and replace it with DayJS, which ended up being a good thing anyway. DayJS has an API that's compatible with Moment.js, but it's a lot smaller than both Moment and Luxon, so it'll save us some bundle weight in addition to respecting locale specific week start days.

I could use a little help testing this change out on staging, just to be sure that the calendar still works correctly, and events can be created and deleted without incident.