### PR TITLE
Recurring events bugfix

### DIFF
--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/stores/cash-flow-store.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/stores/cash-flow-store.js
@@ -264,7 +264,6 @@ export default class CashFlowStore {
   saveEvent = flow(function* (params, updateRecurrences = false) {
     let event;
     let recurrenceTypeChanged = false;
-    let recurringEventDateChanged = false;
 
     if (params.id) {
       this.logger.debug('updating existing event %O', params);

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/stores/cash-flow-store.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/stores/cash-flow-store.js
@@ -276,7 +276,6 @@ export default class CashFlowStore {
       }
 
       if (event.recurs && !event.dateTime.isSame(params.dateTime)) {
-        recurringEventDateChanged = true;
         yield this.deleteRecurrences(event, true);
         params.originalEventID = null;
         updateRecurrences = false;

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/calendar/add/form.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/calendar/add/form.js
@@ -164,7 +164,7 @@ function Form() {
               errors={formik.errors.name}
               touched={formik.touched.name}
               tabIndex="0"
-              placeholder={`e.g. ${category.name}`}
+              placeholder={`For example: ${category.name}`}
             />
 
             <CurrencyField


### PR DESCRIPTION
This fixes odd behavior when altering the date of a recurrence of an event. The app now deletes future recurrences, changes the edited event into a new primary event (i.e. dissociates it from the original first event that created it), and re-creates new recurrences based on the new start date. This prevents duplicate recurrences from accumulating, and it allows users to change individual events anywhere on their calendar to reflect changed payment dates. 