### PR TITLE
fixed fix-it strategies bug

### DIFF
--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/stores/strategies-store.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/stores/strategies-store.js
@@ -26,16 +26,6 @@ class StrategiesStore {
         text: 'How to save for emergencies and the future',
       },
     },
-
-    /* 'expense.personal.healthcare': {
-      id: 'chooseHealthPlan',
-      title: 'Choose a Health Care Plan That Fits Your Budget',
-      body: 'Health insurance can drastically reduce the costs of unforeseen medical bills.',
-      link: {
-        href: 'https://www.healthcare.gov/',
-        text: 'HealthCare.gov',
-      },
-    }, */
   };
 
   fixItStrategies = {
@@ -185,8 +175,10 @@ class StrategiesStore {
         }
 
         if (event.categoryDetails.hasBill) {
-          if (!results.largestBillableExpense || results.largestBillableExpense.isLessThan(event)) {
-            results.largestBillableExpense = event;
+          if (!event.category.includes('expense.housing')) {
+            if (!results.largestBillableExpense || results.largestBillableExpense.isLessThan(event)) {
+              results.largestBillableExpense = event;
+            }
           }
         }
 
@@ -195,7 +187,6 @@ class StrategiesStore {
             results.largestAdHocExpense = event;
           }
         }
-
         return results;
       },
       {


### PR DESCRIPTION
The Fix-It Strategies were not showing the correct strategies, according to @RedNumberIX's flow-chart.





## Additions

-  I edited just one file, strategies-store.js, the analyzeFixItEvents function.  I added the following logic so that when the app calculates which 'Due Date' Fix-It Strategy shows on the screen, it does not include housing expenses.  The proper strategies are showing up now. 
 ``` if (!event.category.includes('expense.housing')) ```


## Removals

- none


## Changes

-  see additions


## How to test this PR

1. Review the code.  
2. Open up the branch locally and add a housing expense, a 'Due Date Expense' (like electricity, gas, etc.) and an 'Ad Hoc Expense' (like clothing, eating out, etc.)


## Screenshots
Here is one screenshot.  If you add one housing, one due date expense and one ad hoc expense, your screen should look something like this.

![Screen Shot 2020-06-19 at 5 58 22 PM](https://user-images.githubusercontent.com/34319929/85183469-d561a080-b259-11ea-8da2-1d802321b8cf.png)
