### PR TITLE
mm/fix-it-bug

### DIFF
--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/stores/strategies-store.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/stores/strategies-store.js
@@ -42,11 +42,7 @@ class StrategiesStore {
     ],
     largestBillableExpense: [
       {
-        categories: [
-          'expense.utilities.fuel',
-          'expense.utilities.waterSewage',
-          'expense.utilities.electricity',
-        ],
+        categories: ['expense.utilities.fuel', 'expense.utilities.waterSewage', 'expense.utilities.electricity'],
         title: 'Budget Utility Billing',
         text: 'Contact your utility company to find out about budget billing',
       },
@@ -137,7 +133,8 @@ class StrategiesStore {
     return [
       {
         title: 'Explore Your General Strategies',
-        text: 'While you have gone into the red, we could not recommend any "Fix It" Strategies based upon your budget. However, there are plenty of solutions you can implement to balance your budget from the general strategies tab.',
+        text:
+          'While you have gone into the red, we could not recommend any "Fix It" Strategies based upon your budget. However, there are plenty of solutions you can implement to balance your budget from the general strategies tab.',
         link: {
           href: '/strategies',
           text: 'View General Strategies',
@@ -177,17 +174,22 @@ class StrategiesStore {
         }
 
         if (event.categoryDetails.hasBill) {
-          if (!results.largestBillableExpense || results.largestBillableExpense.isLessThan(event)) {
-            results.largestBillableExpense = event;
+          if (!event.category.includes('expense.housing')) {
+            if (this.fixItStrategies['largestBillableExpense'].find((sgy) => sgy.categories.includes(event.category))) {
+              if (!results.largestBillableExpense || results.largestBillableExpense.isLessThan(event)) {
+                results.largestBillableExpense = event;
+              }
+            }
           }
         }
 
         if (event.totalCents < 0 && !event.categoryDetails.hasBill) {
-          if (!results.largestAdHocExpense || results.largestAdHocExpense.isLessThan(event)) {
-            results.largestAdHocExpense = event;
+          if (this.fixItStrategies['largestAdHocExpense'].find((sgy) => sgy.categories.includes(event.category))) {
+            if (!results.largestAdHocExpense || results.largestAdHocExpense.isLessThan(event)) {
+              results.largestAdHocExpense = event;
+            }
           }
         }
-
         return results;
       },
       {


### PR DESCRIPTION
I edited the analyzeFixItEvents function to search for an actual strategy to match the category.

_[Enter an explanation of what the pull request does and why.]_


---  Currently, if the largest expense in the 'Billable Expense'  (due date) category or the 'Ad Hoc Expense' (non-due date) category does not have a category, the Fix-it Strategy just goes to General Strategies.  The behavior should be that if the top expense in either of these two categories does not have an associated expense, then, the strategy should show for the next highest expense.  If none of the expenses selected has an associated strategy, only then should the General Strategy show.


## Additions

-  added logic to have the function check the event to see if there is a strategy available for the category.   this.fixItStrategies['largestBillableExpense'].find((sgy) => sgy.categories.includes(event.category))) 

## Screenshots

In this example, there are 2 'Billable Expenses': Electricity $30.00 (there is a strategy) and Internet $75.00 (there is no strategy).  Even though Internet is the highest billable expense, it will now show the strategy for Electricity (the next highest expense that has a strategy).  This is similar to the "Ad Hoc expenses':Clothing $75 and Car Maintenance $150.  Car maintenance is higher but there is no strategy associated so the strategy for clothing is showing.

<img width="271" alt="Screen Shot 2020-06-24 at 3 47 49 PM" src="https://user-images.githubusercontent.com/34319929/85620654-167afb80-b632-11ea-9308-1826faac5649.png">
  


<img width="254" alt="Screen Shot 2020-06-24 at 3 42 22 PM" src="https://user-images.githubusercontent.com/34319929/85620128-568dae80-b631-11ea-8f46-e9448e5ddf48.png">



