### PR TITLE
Mm/fix it strategies bugfix

### DIFF
--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/stores/strategies-store.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/stores/strategies-store.js
@@ -150,13 +150,13 @@ class StrategiesStore {
       const { strategy } = Categories.get(catPath) || {};
       return strategy;
     });
-
     for (const [catPath, strategy] of Object.entries(this.negativeStrategies)) {
+      console.log('this is catPath and strategy', catPath, strategy);
       if (!this.eventStore.eventCategories.includes(catPath)) {
         results.push(strategy);
       }
     }
-
+    results.reverse();
     return compact(results).filter((result) => {
       if (strategyIDs.has(result.id)) return false;
       strategyIDs.add(result.id);

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/stores/strategies-store.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/stores/strategies-store.js
@@ -146,19 +146,23 @@ class StrategiesStore {
 
   @computed get strategyResults() {
     const strategyIDs = new Set();
-    const results = this.eventStore.eventCategories.map((catPath) => {
+    //const results = this.eventStore.eventCategories.map((catPath) => {
+    const list = this.eventStore.eventCategories.map((catPath) => {
       const { strategy } = Categories.get(catPath) || {};
       return strategy;
     });
     for (const [catPath, strategy] of Object.entries(this.negativeStrategies)) {
       if (!this.eventStore.eventCategories.includes(catPath)) {
-        results.push(strategy);
+        list.push(strategy);
       }
     }
-    results.reverse();
-    return compact(results).filter((result) => {
-      if (strategyIDs.has(result.id)) return false;
-      strategyIDs.add(result.id);
+    console.log('list is ', list);
+    let reversedList = [...list].reverse();
+    console.log('reversedList is ', reversedList);
+    //results.reverse();
+    return compact(reversedList).filter((item) => {
+      if (strategyIDs.has(item.id)) return false;
+      strategyIDs.add(item.id);
       this.logger.debug('Strategy IDs set: %O', strategyIDs);
       return true;
     });

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/stores/strategies-store.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/stores/strategies-store.js
@@ -151,7 +151,6 @@ class StrategiesStore {
       return strategy;
     });
     for (const [catPath, strategy] of Object.entries(this.negativeStrategies)) {
-      console.log('this is catPath and strategy', catPath, strategy);
       if (!this.eventStore.eventCategories.includes(catPath)) {
         results.push(strategy);
       }

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/stores/strategies-store.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/stores/strategies-store.js
@@ -176,15 +176,19 @@ class StrategiesStore {
 
         if (event.categoryDetails.hasBill) {
           if (!event.category.includes('expense.housing')) {
-            if (!results.largestBillableExpense || results.largestBillableExpense.isLessThan(event)) {
-              results.largestBillableExpense = event;
+            if (this.fixItStrategies['largestBillableExpense'].find((sgy) => sgy.categories.includes(event.category))) {
+              if (!results.largestBillableExpense || results.largestBillableExpense.isLessThan(event)) {
+                results.largestBillableExpense = event;
+              }
             }
           }
         }
 
         if (event.totalCents < 0 && !event.categoryDetails.hasBill) {
-          if (!results.largestAdHocExpense || results.largestAdHocExpense.isLessThan(event)) {
-            results.largestAdHocExpense = event;
+          if (this.fixItStrategies['largestAdHocExpense'].find((sgy) => sgy.categories.includes(event.category))) {
+            if (!results.largestAdHocExpense || results.largestAdHocExpense.isLessThan(event)) {
+              results.largestAdHocExpense = event;
+            }
           }
         }
         return results;

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/stores/strategies-store.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/stores/strategies-store.js
@@ -146,7 +146,6 @@ class StrategiesStore {
 
   @computed get strategyResults() {
     const strategyIDs = new Set();
-    //const results = this.eventStore.eventCategories.map((catPath) => {
     const list = this.eventStore.eventCategories.map((catPath) => {
       const { strategy } = Categories.get(catPath) || {};
       return strategy;
@@ -156,10 +155,9 @@ class StrategiesStore {
         list.push(strategy);
       }
     }
-    console.log('list is ', list);
+
     let reversedList = [...list].reverse();
-    console.log('reversedList is ', reversedList);
-    //results.reverse();
+
     return compact(reversedList).filter((item) => {
       if (strategyIDs.has(item.id)) return false;
       strategyIDs.add(item.id);


### PR DESCRIPTION
I edited the analyzeFixItEvents function to search for an actual strategy to match the category.  I also re-ordered the _General Strategies_ so it shows _Save for Emergencies_, _Corona Virus_ messaging, then, all the rest.

[Enter an explanation of what the pull request does and why.]

- Currently, if the largest expense in the 'Billable Expense' (due date) category or the 'Ad Hoc Expense' (non-due date) category does not have a category, the Fix-it Strategy just goes to General Strategies. The behavior should be that if the top expense in either of these two categories does not have an associated expense, then, the strategy should show for the next highest expense. If none of the expenses selected has an associated strategy, only then should the General Strategy show.

- Also, currently, the  _General Strategies_ were not ordered correctly. 

**_Additions_**
- added logic to have the function check the event to see if there is a strategy available for the category. this.fixItStrategies['largestBillableExpense'].find((sgy) => sgy.categories.includes(event.category)))
Screenshots
   - In this example, there are 2 'Billable Expenses': Electricity $30.00 (there is a strategy) and Internet $75.00 (there is no strategy). Even though Internet is the highest billable expense, it will now show the strategy for Electricity (the next highest expense that has a strategy). This is similar to the "Ad Hoc expenses':Clothing $75 and Car Maintenance $150. Car maintenance is higher but there is no strategy associated so the strategy for clothing is showing.
- The _General Strategies_ are ordered as described above.

**_To Test this PR_**

- Start app from scratch.  Add $0 for a starting balance.
- Add a _mortgage expense_ and a _rent expense_ in the same week.  Tap Fix-It Strategies. You should see the strategy for the largest of these two Housing categories.
- Add two categories of Due-Date expenses, 1 that has a strategy and 1 that does not. (see issue #72) in the same week.  Tap Fix-it Strategies.  You should see the largest expense that has a strategy associated with it.
- Add two categories of Non-Due-Date expenses, 1 that has a strategy and 1 that does not in the same week (see issue #72).  Tap Fix-it Strategies.  You should see the largest expense that has a strategy associated with it.
- View the _General Strategies_ below.  The order should be the same as described in the first comment of this PR.

![Screen Shot 2020-06-19 at 5 58 22 PM](https://user-images.githubusercontent.com/34319929/85642298-20ffba00-b65f-11ea-8830-5e19f01ea85f.png)

<img width="170" alt="Screen Shot 2020-06-24 at 9 09 18 PM" src="https://user-images.githubusercontent.com/34319929/85642273-075e7280-b65f-11ea-976e-97f4a9f467e8.png">
