### PR TITLE
revised message on Gen Strategies when there are none to show

### DIFF
--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/stores/strategies-store.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/stores/strategies-store.js
@@ -135,11 +135,7 @@ class StrategiesStore {
       {
         title: 'Explore Your General Strategies',
         text:
-          'While you have gone into the red, we could not recommend any "Fix It" Strategies based upon your budget. However, there are plenty of solutions you can implement to balance your budget from the general strategies tab.',
-        link: {
-          href: '/strategies',
-          text: 'View General Strategies',
-        },
+          "Based upon your weekly transactions we can't recommend any Fix-It Strategies. Make sure that you've entered in all of your expenses and income for the week then check back here later.  Otherwise, review the generic strategies below.",
       },
     ];
   }

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/strategies/fix-it/index.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/strategies/fix-it/index.js
@@ -45,7 +45,7 @@ const StrategyCards = ({ results }) => (
         <Card title={result.title} icon={ideaRound} key={`strategy-${index}`}>
           <p>{result.text}</p>
           <div className="m-card_footer">
-            <FixItButton result={result} />
+            {!result.title === 'Explore Your General Strategies' && <FixItButton result={result} />}
           </div>
         </Card>
       ))}


### PR DESCRIPTION
Closes #78 

If there are no strategies to display, the message shown to the user was confusing and had a link to the General Strategies that were already right below it.

## Additions
- Added one line of logic so that a link doesn't display if that particular card results. (/js/views/strategies/fix-it/index.js)
- Changed copy of the message per Ryan's suggestion. 

## Removals
- Deleted link and text in file that finds this card.  (js/stores/strategies-store.js )


## How to test this PR

1. Clear the data and start app as a new user.
2. Add $500 as a _Starting Balance_.
3. Add $1000 _Car Maintenance_ expense.
4. Move to week that puts you in the red.

There should be no strategies showing except the card explaining why there are no strategies and instructing the user to add more transactions.  There should be no link.

<img width="285" alt="Screen Shot 2020-06-26 at 7 10 22 PM" src="https://user-images.githubusercontent.com/34319929/85908347-b37c9680-b7e2-11ea-96aa-b8cc5f111afc.png">



