### PR TITLE
Mm/fix it changes

### DIFF
--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/components/bottom-nav.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/components/bottom-nav.js
@@ -46,7 +46,7 @@ function BottomNav() {
       <nav className="bottom-nav__nav">
         <ul className="bottom-nav__items">
           <NavItem href="/calendar" icon={calendar} exact label="Calendar" disabled={!hasStartingBalance} />
-          <NavItem href="/calendar/add/income" icon={add} label="Add" disabled={!hasStartingBalance} />
+          <NavItem href="/calendar/add/income" icon={add} label="Income/Expense" disabled={!hasStartingBalance} />
           <NavItem
             href="/strategies"
             icon={idea}

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/stores/cash-flow-store.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/stores/cash-flow-store.js
@@ -292,7 +292,7 @@ export default class CashFlowStore {
   }
 
   /**
-   * Missy added:  Gets all positive events occurring in the same week as the specified date
+   * Gets all positive events occurring in the same week as the specified date
    *
    * @param {Date|dayjs} date - A date in the week to check
    * @returns {CashFlowEvent[]|undefined}

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/stores/models/day.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/stores/models/day.js
@@ -16,8 +16,8 @@ export default class Day {
     this.logger = logger.addGroup('day');
 
     if (previousDay) {
-     this.snapBalance = previousDay.snapBalance + this.snapTotal;
-     this.nonSnapBalance = previousDay.nonSnapBalance + this.nonSnapTotal;
+      this.snapBalance = previousDay.snapBalance + this.snapTotal;
+      this.nonSnapBalance = previousDay.nonSnapBalance + this.nonSnapTotal;
     }
 
     // SNAP can't go below 0

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/stores/strategies-store.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/stores/strategies-store.js
@@ -161,30 +161,6 @@ class StrategiesStore {
   analyzeFixItEvents(events) {
     return events.reduce(
       (results, event) => {
-        if (/^expense\.housing/.test(event.category)) {
-          if (!results.largestHousingExpense || results.largestHousingExpense.isLessThan(event)) {
-            results.largestHousingExpense = event;
-          }
-        }
-
-        /*  if (event.categoryDetails.hasBill) {
-          if (!event.category.includes('expense.housing')) {
-            if (this.fixItStrategies['largestBillableExpense'].find((sgy) => sgy.categories.includes(event.category))) {
-              if (!results.largestBillableExpense || results.largestBillableExpense.isLessThan(event)) {
-                results.largestBillableExpense = event;
-              }
-            }
-          }
-        } */
-
-        if (event.categoryDetails.hasBill && !event.category.includes('expense.housing')) {
-          if (this.fixItStrategies['largestBillableExpense'].find((sgy) => sgy.categories.includes(event.category))) {
-            if (!results.largestBillableExpense || results.largestBillableExpense.isLessThan(event)) {
-              results.largestBillableExpense = event;
-            }
-          }
-        }
-
         if (event.totalCents < 0 && !event.categoryDetails.hasBill) {
           if (this.fixItStrategies['largestAdHocExpense'].find((sgy) => sgy.categories.includes(event.category))) {
             if (!results.largestAdHocExpense || results.largestAdHocExpense.isLessThan(event)) {
@@ -192,12 +168,29 @@ class StrategiesStore {
             }
           }
         }
+
+        if (event.categoryDetails.hasBill) {
+          if (!event.category.includes('expense.housing')) {
+            if (this.fixItStrategies['largestBillableExpense'].find((sgy) => sgy.categories.includes(event.category))) {
+              if (!results.largestBillableExpense || results.largestBillableExpense.isLessThan(event)) {
+                results.largestBillableExpense = event;
+              }
+            }
+          }
+        }
+
+        if (/^expense\.housing/.test(event.category)) {
+          if (!results.largestHousingExpense || results.largestHousingExpense.isLessThan(event)) {
+            results.largestHousingExpense = event;
+          }
+        }
+
         return results;
       },
       {
-        largestHousingExpense: undefined,
-        largestBillableExpense: undefined,
         largestAdHocExpense: undefined,
+        largestBillableExpense: undefined,
+        largestHousingExpense: undefined,
       }
     );
   }

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/stores/strategies-store.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/stores/strategies-store.js
@@ -82,7 +82,8 @@ class StrategiesStore {
           'expense.personal.funMoney',
         ],
         title: 'Adjust Spending this Week',
-        template: (categoryName) => `Your ${categoryName.toLowerCase()} expense was your largest expense this week not tied to a bill you are obligated to pay. Consider spending a little less this week and a little more in weeks where you have fewer expenses or more income.`,
+        template: (categoryName) =>
+          `Your ${categoryName.toLowerCase()} expense was your largest expense this week not tied to a bill you are obligated to pay. Consider spending a little less this week and a little more in weeks where you have fewer expenses or more income.`,
       },
     ],
   };
@@ -166,12 +167,20 @@ class StrategiesStore {
           }
         }
 
-        if (event.categoryDetails.hasBill) {
+        /*  if (event.categoryDetails.hasBill) {
           if (!event.category.includes('expense.housing')) {
             if (this.fixItStrategies['largestBillableExpense'].find((sgy) => sgy.categories.includes(event.category))) {
               if (!results.largestBillableExpense || results.largestBillableExpense.isLessThan(event)) {
                 results.largestBillableExpense = event;
               }
+            }
+          }
+        } */
+
+        if (event.categoryDetails.hasBill && !event.category.includes('expense.housing')) {
+          if (this.fixItStrategies['largestBillableExpense'].find((sgy) => sgy.categories.includes(event.category))) {
+            if (!results.largestBillableExpense || results.largestBillableExpense.isLessThan(event)) {
+              results.largestBillableExpense = event;
             }
           }
         }

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/stores/ui-store.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/stores/ui-store.js
@@ -38,7 +38,6 @@ export default class UIStore {
     window.addEventListener('beforeinstallprompt', this.setInstallPromptEvent);
   }
 
-
   @computed get monthCalendarRows() {
     return getWeekRows(this.currentMonth);
   }

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/strategies/fix-it/index.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/strategies/fix-it/index.js
@@ -45,7 +45,7 @@ const StrategyCards = ({ results }) => (
         <Card title={result.title} icon={ideaRound} key={`strategy-${index}`}>
           <p>{result.text}</p>
           <div className="m-card_footer">
-            {!result.title === 'Explore Your General Strategies' && <FixItButton result={result} />}
+            {result.title === 'Explore Your General Strategies' ? null : <FixItButton result={result} />}
           </div>
         </Card>
       ))}
@@ -81,40 +81,35 @@ function FixItStrategies() {
         <h2 className="strategies-header__title">Fix-It Strategies</h2>
         {strategies.fixItResults.length ? (
           <div className="strategy-cards">
-            <h3 className="strategies-header__week-range">{uiStore.weekRangeText}</h3>
+            <h3 className="strategies-header__week-range">Week of {uiStore.weekRangeText}</h3>
             <CardGroup columns={2}>
               <div className="fixit-header">
                 <div className="fixit-header__line-first">
-                  <div>
-                    Amount that puts you in{' '}
-                    <strong>
-                      <em>RED</em>
-                    </strong>
-                    :
-                  </div>
+                  <div>Amount that you went over: </div>
                   <div className="fixit-header__amount">{uiStore.weekEndingBalanceText}</div>
                 </div>
 
                 <div className="fixit-header__line">
-                  The amount that puts you in{' '}
-                  <strong>
-                    <em>RED</em>
-                  </strong>{' '}
-                  is what you should try to reduce.
+                  The amount you went over is what you should try to reduce. The strategies below can help.
                 </div>
               </div>
               <div className="fixit-header">
                 <div className="fixit-header__comment">
-                  <div>Weekly Starting Balance:</div>
+                  <div>Starting Balance:</div>
                   <div className="fixit-header__comment-value">{uiStore.weekStartingBalanceText}</div>
                 </div>
                 <div className="fixit-header__comment">
-                  <div>Total Weekly Income: </div>
+                  <div>Weekly Income: </div>
                   <div className="fixit-header__comment-value">{formatCurrency(weekIncome)}</div>
                 </div>
                 <div className="fixit-header__comment">
-                  <div>Total Weekly Expense:</div>
+                  <div>Weekly Expense:</div>
                   <div className="fixit-header__comment-value">{formatCurrency(weekExpenses)}</div>
+                </div>
+              </div>
+              <div className="fixit-header">
+                <div className="fixit-header__comment">
+                  <div>You currently have a SNAP balance of {uiStore.weekEndingSnapBalanceText}.</div>
                 </div>
               </div>
             </CardGroup>


### PR DESCRIPTION
There were several changes as outlined below:

- the appearance of the 3 categories of `Fix-It Strategies` was reordered per the client's request
- the label for the '+' on the bottom nav was changed to 'Income/Expense'
- copy/formatting on the `Fix It Strategies` header sections were changed per the client's request
- an additional sectionwas added to the `Fix It Strategies` headers to reflect the user's `SNAP balance`.

## How to test this PR

1. open branch locally and run `gulp scripts:moneytools`
2. make sure local cache is cleared and that you are at the home page.
3. Enter $100 as a starting balance.
4. Enter `rent` for $1000 on July 1, recurring monthly.
5. Enter `SNAP benefit` for $500, on July 2, recurring monthly.
6. Enter `Groceries` for $125, on July 3, recurring weekly.

- view bottom nav bar to see change in label noted above.
- The first week, week of 06/28/2020 should have triggered `fix-it` button. Click the button and view the different headers.  The headers should have the following copy and the math should be right.  (i.e. if The SNAP benefit  should be $500 - $125 or $375)
- the order should be `ad hoc (non-due-date) item` strategy first, `item with due date` strategy next and `housing` strategy next.


## Screenshots
<img width="262" alt="Screen Shot 2020-06-30 at 4 22 39 PM" src="https://user-images.githubusercontent.com/34319929/86173863-aadfd500-baee-11ea-88fd-0435b98a2ae4.png">
<img width="171" alt="Screen Shot 2020-06-30 at 4 23 34 PM" src="https://user-images.githubusercontent.com/34319929/86173877-addac580-baee-11ea-98a5-930064487f6a.png">




