### PR TITLE
reset narrative notification flags on clear all data action

### DIFF
--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/stores/cash-flow-store.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/stores/cash-flow-store.js
@@ -13,7 +13,7 @@ export default class CashFlowStore {
   @observable eventsLoaded = false;
   @observable events = [];
   @observable modalOpen = localStorage.getItem('removeSpotlight') ? false : true;
-
+  
   constructor(rootStore) {
     this.rootStore = rootStore;
     this.logger = logger.addGroup('cashFlowStore');
@@ -514,10 +514,12 @@ export default class CashFlowStore {
    */
   clearAllData = flow(function* () {
     yield CashFlowEvent.destroyAll();
+    localStorage.clear();
+    this.modalOpen = true;
     this.setEvents([]);
   });
 
   @action closeNarrativeModal() {
     this.modalOpen = !this.modalOpen;
-  } 
+  }
 }


### PR DESCRIPTION
Will close #90

## Additions

- Added logic to clear flags in localStorage that track the launching of the narrative notifications. Now upon a user clearing all data from the site via the Clear My Data button when re enter data, this will trigger the narrative notifications again from scratch.

## How to test this PR

Review on Dev
https://cfgov-refresh-dev.herokuapp.com/mmt-my-money-calendar

```
- Step through app
- enter initial balance
- Take note of narrative notifications upon entering initial balance, after first transaction, etc.
- Navigate to 'More'
- Clear My Data
- Start over and note that narrative notifications launch

```