### PR TITLE
Start balance logic adjusted and copy changes

### DIFF
--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/stores/strategies-store.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/stores/strategies-store.js
@@ -35,7 +35,7 @@ class StrategiesStore {
       },
       {
         categories: ['expense.housing.rent'],
-        title: 'Split Rent Payments',
+        title: 'Split Rent Payment',
         text: 'Contact your landlord to find out if you could split your payment into two payments per month',
       },
     ],

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/calendar/index/day.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/calendar/index/day.js
@@ -38,7 +38,6 @@ function Day({ day, dateFormat = 'D' }) {
   if (!eventStore.events.length) return emptyTile(classes);
 
   const balance = eventStore.getBalanceForDate(day);
-  console.log('week ending balance', uiStore.weekEndingBalanceText);
 
   classes.push({
     'pos-balance': balance >= 0 && day.isSameOrAfter(eventStore.earliestEventDate),

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/calendar/index/day.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/calendar/index/day.js
@@ -38,6 +38,7 @@ function Day({ day, dateFormat = 'D' }) {
   if (!eventStore.events.length) return emptyTile(classes);
 
   const balance = eventStore.getBalanceForDate(day);
+  console.log('week ending balance', uiStore.weekEndingBalanceText);
 
   classes.push({
     'pos-balance': balance >= 0 && day.isSameOrAfter(eventStore.earliestEventDate),

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/calendar/index/details.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/calendar/index/details.js
@@ -85,6 +85,10 @@ function Details() {
   useLockBodyScroll(modalOpen);
 
   const events = eventStore.getEventsForWeek(uiStore.currentWeek) || [];
+  const startBal = events
+    .filter((x) => x.category === 'income.startingBalance')
+    .map((e) => formatCurrency(e.totalCents / 100));
+
   const endBalanceClasses = clsx('calendar-details__ending-balance', uiStore.weekHasNegativeBalance && 'negative');
 
   return (
@@ -100,7 +104,10 @@ function Details() {
         <div className="calendar-details__header-text">
           <h3>Week of {uiStore.weekRangeText}</h3>
           <div className="calendar-details__starting-balance">
-            Starting Balance: <span className="balance-amount">{uiStore.weekStartingBalanceText}</span>
+            Starting Balance:{' '}
+            <span className="balance-amount">
+              {events.find((x) => x.category === 'income.startingBalance') ? startBal : uiStore.weekStartingBalanceText}
+            </span>
           </div>
           {!uiStore.weekHasNegativeBalance && !eventStore.hasSnapEvents && (
             <div className={endBalanceClasses}>

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/calendar/index/details.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/calendar/index/details.js
@@ -98,17 +98,23 @@ function Details() {
         />
 
         <div className="calendar-details__header-text">
-          <h3>{uiStore.weekRangeText}</h3>
+          <h3>Week of {uiStore.weekRangeText}</h3>
           <div className="calendar-details__starting-balance">
-            Weekly Starting Balance: <span className='balance-amount'>{uiStore.weekStartingBalanceText}</span>
+            Starting Balance: <span className="balance-amount">{uiStore.weekStartingBalanceText}</span>
           </div>
           {!uiStore.weekHasNegativeBalance && !eventStore.hasSnapEvents && (
-            <div className={endBalanceClasses}>Weekly Ending Balance: <span className='balance-amount'>{uiStore.weekEndingBalanceText}</span></div>
+            <div className={endBalanceClasses}>
+              Ending Balance: <span className="balance-amount">{uiStore.weekEndingBalanceText}</span>
+            </div>
           )}
           {!uiStore.weekHasNegativeBalance && eventStore.hasSnapEvents && (
             <div className={endBalanceClasses}>
-              <p>Weekly Ending Balance: <span className='balance-amount'>{uiStore.weekEndingBalanceText}</span></p>
-              <p>Weekly Ending SNAP Balance: <span className='balance-amount'>{uiStore.weekEndingSnapBalanceText}</span></p>
+              <p>
+                Ending Balance: <span className="balance-amount">{uiStore.weekEndingBalanceText}</span>
+              </p>
+              <p>
+                Ending SNAP Balance: <span className="balance-amount">{uiStore.weekEndingSnapBalanceText}</span>
+              </p>
             </div>
           )}
         </div>
@@ -133,14 +139,14 @@ function Details() {
             }
           >
             <p className="m-notification_explanation">
-              Weekly Ending Balance: <span className="neg-ending-balance">{uiStore.weekEndingBalanceText}</span>
+              Ending Balance: <span className="neg-ending-balance">{uiStore.weekEndingBalanceText}</span>
             </p>
           </Notification>
         </div>
       )}
 
       <div className="calendar-details__events-section">
-        <h3 className="calendar-details__events-section-title">Weekly Transactions</h3>
+        <h3 className="calendar-details__events-section-title">Transactions</h3>
 
         <ul className="calendar-details__events-list">
           {events.map((e) => (

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/calendar/index/details.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/calendar/index/details.js
@@ -104,7 +104,7 @@ function Details() {
         <div className="calendar-details__header-text">
           <h3>Week of {uiStore.weekRangeText}</h3>
           <div className="calendar-details__starting-balance">
-            Starting Balance:{' '}
+            Starting Balance:
             <span className="balance-amount">
               {events.find((x) => x.category === 'income.startingBalance') ? startBal : uiStore.weekStartingBalanceText}
             </span>

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/money-on-hand/start.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/money-on-hand/start.js
@@ -8,21 +8,22 @@ import hero from 'img/Hero_2.png';
 export default function Start() {
   useScrollToTop();
 
-
   return (
     <>
       <Hero
-        title="MyMoney Calendar"
+        title="myMoney Calendar"
         subtitle="See how your money flows from week to week and learn how to avoid coming up short."
         image={hero}
-        alt="MyMoney Calendar"
+        alt="myMoney Calendar"
       />
       <br />
       <div className="m-hero_subhead">
         <p>Enter your income, expenses, and cash-on-hand to build your calendar.</p>
         <p>It's okay to estimate.</p>
 
-        <ButtonLink icon={arrowRight} iconSide="right" to="/money-on-hand/sources">Get Started</ButtonLink>
+        <ButtonLink icon={arrowRight} iconSide="right" to="/money-on-hand/sources">
+          Get Started
+        </ButtonLink>
       </div>
     </>
   );

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/money-on-hand/summary.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/money-on-hand/summary.js
@@ -58,7 +58,7 @@ function Summary() {
 
             return (
               <li key={`funding-src-${idx}`} className="funding-source">
-                <span className="funding-source__name">{name}:</span>{' '}
+                <span className="funding-source__name">{name}:</span>
                 <span className="funding-source__balance">{formatCurrency(balance / 100)}</span>
               </li>
             );

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/more/export.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/more/export.js
@@ -15,11 +15,13 @@ function Export() {
   return (
     <section className={bem()}>
       <header className={bem('header')}>
-        <h1 className={bem('app-title')}>MyMoney Calendar</h1>
+        <h1 className={bem('app-title')}>myMoney Calendar</h1>
         <h2 className={bem('section-title')}>Save {dataType}</h2>
       </header>
 
-      <ButtonLink to="/more" variant="secondary">Back</ButtonLink>
+      <ButtonLink to="/more" variant="secondary">
+        Back
+      </ButtonLink>
     </section>
   );
 }

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/more/index.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/more/index.js
@@ -14,14 +14,11 @@ function More() {
   const history = useHistory();
   const [clearDataModalOpen, toggleClearDataModal] = useToggle(false);
 
-  const clearAllData = useCallback(
-    async (evt) => {
-      evt.preventDefault();
-      await eventStore.clearAllData();
-      history.push('/');
-    },
-    [eventStore, history]
-  );
+  const clearAllData = useCallback(async (evt) => {
+    evt.preventDefault();
+    await eventStore.clearAllData();
+    history.push('/');
+  }, [eventStore, history]);
 
   useScrollToTop();
 

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/more/index.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/more/index.js
@@ -14,47 +14,38 @@ function More() {
   const history = useHistory();
   const [clearDataModalOpen, toggleClearDataModal] = useToggle(false);
 
-  const clearAllData = useCallback(async (evt) => {
-    evt.preventDefault();
-    await eventStore.clearAllData();
-    history.push('/');
-  }, [eventStore, history]);
+  const clearAllData = useCallback(
+    async (evt) => {
+      evt.preventDefault();
+      await eventStore.clearAllData();
+      history.push('/');
+    },
+    [eventStore, history]
+  );
 
   useScrollToTop();
 
   return (
     <section className={bem()}>
       <header className={bem('header')}>
-        <h1 className={bem('app-title')}>MyMoney Calendar</h1>
+        <h1 className={bem('app-title')}>myMoney Calendar</h1>
         <h2 className={bem('section-title')}>More Options</h2>
       </header>
 
       <main className={bem('main')}>
         <ul className={bem('actions')}>
           <li className={bem('actions-item')}>
-            <ButtonLink
-              fullWidth
-              variant="primary"
-              to="/more/export/strategies"
-            >
+            <ButtonLink fullWidth variant="primary" to="/more/export/strategies">
               Save Strategies
             </ButtonLink>
           </li>
           <li className={bem('actions-item')}>
-            <ButtonLink
-              fullWidth
-              variant="primary"
-              to="/more/export/calendar"
-            >
+            <ButtonLink fullWidth variant="primary" to="/more/export/calendar">
               Save Calendar
             </ButtonLink>
           </li>
           <li className={bem('actions-item')}>
-            <Button
-              fullWidth
-              variant="warning"
-              onClick={() => toggleClearDataModal(true)}
-            >
+            <Button fullWidth variant="warning" onClick={() => toggleClearDataModal(true)}>
               Clear My Data
             </Button>
           </li>

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/strategies/fix-it/index.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/strategies/fix-it/index.js
@@ -79,7 +79,7 @@ function FixItStrategies() {
     const weekInt = Number(week);
 
     if (weekInt && weekInt !== uiStore.currentWeek.valueOf()) uiStore.setCurrentWeek(dayjs(weekInt));
-    handleModalSession();
+    handleModalSession()
   }, []);
 
   const handleToggleModal = (event) => {
@@ -98,7 +98,9 @@ function FixItStrategies() {
   return (
     <section className="strategies">
       {showModal && (
-        <NarrativeModal showModal={showModal} handleOkClick={handleToggleModal} copy={narrativeCopy.step3} />
+        <NarrativeModal showModal={showModal}
+                        handleOkClick={handleToggleModal}
+                        copy={narrativeCopy.step3} />
       )}
       <header className="strategies-header">
         <h2 className="strategies-header__title">Fix-It Strategies</h2>
@@ -138,10 +140,10 @@ function FixItStrategies() {
             </CardGroup>
           </div>
         ) : (
-          <p>
-            <em>There are no strategy recommendations for this week</em>
-          </p>
-        )}
+            <p>
+              <em>There are no strategy recommendations for this week</em>
+            </p>
+          )}
       </header>
       <div>{strategies.fixItResults.length > 0 && <StrategyCards results={strategies.fixItResults} />}</div>
       <div>

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/strategies/fix-it/index.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/strategies/fix-it/index.js
@@ -79,7 +79,7 @@ function FixItStrategies() {
     const weekInt = Number(week);
 
     if (weekInt && weekInt !== uiStore.currentWeek.valueOf()) uiStore.setCurrentWeek(dayjs(weekInt));
-    handleModalSession()
+    handleModalSession();
   }, []);
 
   const handleToggleModal = (event) => {
@@ -97,12 +97,9 @@ function FixItStrategies() {
   var weekExpenses = negativeFilter.reduce((acc, event) => acc + event.total, 0);
   return (
     <section className="strategies">
-      { showModal && 
-        <NarrativeModal showModal={showModal}
-                        handleOkClick={handleToggleModal}
-                        copy={narrativeCopy.step3}
-        />
-      }
+      {showModal && (
+        <NarrativeModal showModal={showModal} handleOkClick={handleToggleModal} copy={narrativeCopy.step3} />
+      )}
       <header className="strategies-header">
         <h2 className="strategies-header__title">Fix-It Strategies</h2>
         {strategies.fixItResults.length ? (
@@ -125,11 +122,11 @@ function FixItStrategies() {
                   <div className="fixit-header__comment-value">{uiStore.weekStartingBalanceText}</div>
                 </div>
                 <div className="fixit-header__comment">
-                  <div>Weekly Income: </div>
+                  <div>Income: </div>
                   <div className="fixit-header__comment-value">{formatCurrency(weekIncome)}</div>
                 </div>
                 <div className="fixit-header__comment">
-                  <div>Weekly Expense:</div>
+                  <div>Expense:</div>
                   <div className="fixit-header__comment-value">{formatCurrency(weekExpenses)}</div>
                 </div>
               </div>


### PR DESCRIPTION
For the first week that the user starts with the app, the _Week Starting Balance_ should be the amount of the _starting balance transaction_.  In all other weeks, the _Week Starting Balance_ is the amount calculated in the _@computed get weekStartingBalanceText()_ in the ui-store.js. 

Closing #91 
Closing #92 


## How to test this PR

1.  Open the updated app locally. 
2.  Add a _starting balance_
3. When you arrive at the Calendar View, review the first week and see the _Starting Balance_ on the header of the detail area.  It should be the amount you entered as the _starting balance_.  
4.  View the following copy changes:
<img width="400" alt="Screen Shot 2020-07-03 at 10 33 41 AM" src="https://user-images.githubusercontent.com/34319929/86478712-b7477600-bd18-11ea-9797-73d03b1f6409.png">



## Screenshots

<p float="left">
<img width="150" alt="Screen Shot 2020-07-03 at 10 21 20 AM" src="https://user-images.githubusercontent.com/34319929/86478232-f2957500-bd17-11ea-8a7b-ea590214205e.png">
<img width="150" alt="Screen Shot 2020-07-03 at 10 21 28 AM" src="https://user-images.githubusercontent.com/34319929/86478231-f2957500-bd17-11ea-851d-cd9e5f3633f5.png">
<img width="150" alt="Screen Shot 2020-07-03 at 10 21 40 AM" src="https://user-images.githubusercontent.com/34319929/86478230-f2957500-bd17-11ea-9bc5-0ee2e54b4f34.png">
</p>
<p><img width="150" alt="Screen Shot 2020-07-03 at 10 21 50 AM" src="https://user-images.githubusercontent.com/34319929/86478229-f1fcde80-bd17-11ea-9125-a2f91ec689c0.png"><img width="150" alt="Screen Shot 2020-07-03 at 10 22 02 AM" src="https://user-images.githubusercontent.com/34319929/86478228-f1fcde80-bd17-11ea-9b9f-6ef68a79d548.png">
<img width="150" alt="Screen Shot 2020-07-03 at 10 20 36 AM" src="https://user-images.githubusercontent.com/34319929/86478233-f2957500-bd17-11ea-84d2-305715be774c.png">
</p>


