### PR TITLE
Changed daily color changes to weekly color changes

### DIFF
--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/lib/calendar-helpers.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/lib/calendar-helpers.js
@@ -3,6 +3,7 @@ import yearDay from 'dayjs/plugin/dayOfYear';
 import weekOfYear from 'dayjs/plugin/weekOfYear';
 import isSameOrAfter from 'dayjs/plugin/isSameOrAfter';
 import isSameOrBefore from 'dayjs/plugin/isSameOrBefore';
+import isBetween from 'dayjs/plugin/isBetween';
 import customParseFormat from 'dayjs/plugin/customParseFormat';
 import { RRule, RRuleSet } from 'rrule';
 
@@ -11,18 +12,11 @@ dayjs.extend(weekOfYear);
 dayjs.extend(customParseFormat);
 dayjs.extend(isSameOrAfter);
 dayjs.extend(isSameOrBefore);
+dayjs.extend(isBetween);
 
-export { dayjs as dayjs };
+export { dayjs };
 
-export const DAY_NAMES = [
-  'Sunday',
-  'Monday',
-  'Tuesday',
-  'Wednesday',
-  'Thursday',
-  'Friday',
-  'Saturday',
-];
+export const DAY_NAMES = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
 export const DAY_LABELS = DAY_NAMES.map((name) => name.charAt(0));
 export const MONTH_NAMES = [
   'January',
@@ -131,12 +125,17 @@ export function getWeekRows(date) {
 
   let currentWeekStart = date.startOf('week');
 
-  while (currentWeekStart.startOf('week').isSame(date, 'month') || currentWeekStart.endOf('week').isSame(date, 'month')) {
+  while (
+    currentWeekStart.startOf('week').isSame(date, 'month') ||
+    currentWeekStart.endOf('week').isSame(date, 'month')
+  ) {
     const weekNumber = currentWeekStart.week();
 
     rows.push({
       weekNumber,
-      days: Array(7).fill(0).map((n, idx) => currentWeekStart.add(n + idx, 'days')),
+      days: Array(7)
+        .fill(0)
+        .map((n, idx) => currentWeekStart.add(n + idx, 'days')),
     });
 
     currentWeekStart = currentWeekStart.add(1, 'week');
@@ -160,8 +159,7 @@ export const DAY_OPTIONS = {
 export const recurrenceRules = {
   weekly: {
     label: 'Weekly',
-    handler: (dtstart, options = {}) =>
-      new RRule({ freq: RRule.WEEKLY, dtstart, ...options }),
+    handler: (dtstart, options = {}) => new RRule({ freq: RRule.WEEKLY, dtstart, ...options }),
   },
   biweekly: {
     label: 'Every 2 weeks',

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/lib/calendar-helpers.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/lib/calendar-helpers.js
@@ -161,6 +161,7 @@ export const recurrenceRules = {
     label: 'Weekly',
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
     handler: (dtstart, options = {}) => 
       new RRule({ freq: RRule.WEEKLY, dtstart, ...options }),
 =======
@@ -170,6 +171,9 @@ export const recurrenceRules = {
     handler: (dtstart, options = {}) => 
       new RRule({ freq: RRule.WEEKLY, dtstart, ...options }),
 >>>>>>> 8cc646fbf... corrected formatting issues
+=======
+    handler: (dtstart, options = {}) => new RRule({ freq: RRule.WEEKLY, dtstart, ...options }),
+>>>>>>> 655a87903... weeks are changing colors correctly
   },
   biweekly: {
     label: 'Every 2 weeks',

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/lib/calendar-helpers.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/lib/calendar-helpers.js
@@ -159,21 +159,7 @@ export const DAY_OPTIONS = {
 export const recurrenceRules = {
   weekly: {
     label: 'Weekly',
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-    handler: (dtstart, options = {}) => 
-      new RRule({ freq: RRule.WEEKLY, dtstart, ...options }),
-=======
     handler: (dtstart, options = {}) => new RRule({ freq: RRule.WEEKLY, dtstart, ...options }),
->>>>>>> 3fb2684bd... weeks are changing colors correctly
-=======
-    handler: (dtstart, options = {}) => 
-      new RRule({ freq: RRule.WEEKLY, dtstart, ...options }),
->>>>>>> 8cc646fbf... corrected formatting issues
-=======
-    handler: (dtstart, options = {}) => new RRule({ freq: RRule.WEEKLY, dtstart, ...options }),
->>>>>>> 655a87903... weeks are changing colors correctly
   },
   biweekly: {
     label: 'Every 2 weeks',

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/lib/calendar-helpers.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/lib/calendar-helpers.js
@@ -159,8 +159,12 @@ export const DAY_OPTIONS = {
 export const recurrenceRules = {
   weekly: {
     label: 'Weekly',
+<<<<<<< HEAD
     handler: (dtstart, options = {}) => 
       new RRule({ freq: RRule.WEEKLY, dtstart, ...options }),
+=======
+    handler: (dtstart, options = {}) => new RRule({ freq: RRule.WEEKLY, dtstart, ...options }),
+>>>>>>> 3fb2684bd... weeks are changing colors correctly
   },
   biweekly: {
     label: 'Every 2 weeks',

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/lib/calendar-helpers.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/lib/calendar-helpers.js
@@ -159,7 +159,8 @@ export const DAY_OPTIONS = {
 export const recurrenceRules = {
   weekly: {
     label: 'Weekly',
-    handler: (dtstart, options = {}) => new RRule({ freq: RRule.WEEKLY, dtstart, ...options }),
+    handler: (dtstart, options = {}) => 
+      new RRule({ freq: RRule.WEEKLY, dtstart, ...options }),
   },
   biweekly: {
     label: 'Every 2 weeks',

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/lib/calendar-helpers.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/lib/calendar-helpers.js
@@ -160,11 +160,16 @@ export const recurrenceRules = {
   weekly: {
     label: 'Weekly',
 <<<<<<< HEAD
+<<<<<<< HEAD
     handler: (dtstart, options = {}) => 
       new RRule({ freq: RRule.WEEKLY, dtstart, ...options }),
 =======
     handler: (dtstart, options = {}) => new RRule({ freq: RRule.WEEKLY, dtstart, ...options }),
 >>>>>>> 3fb2684bd... weeks are changing colors correctly
+=======
+    handler: (dtstart, options = {}) => 
+      new RRule({ freq: RRule.WEEKLY, dtstart, ...options }),
+>>>>>>> 8cc646fbf... corrected formatting issues
   },
   biweekly: {
     label: 'Every 2 weeks',

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/stores/cash-flow-store.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/stores/cash-flow-store.js
@@ -13,7 +13,7 @@ export default class CashFlowStore {
   @observable eventsLoaded = false;
   @observable events = [];
   @observable modalOpen = localStorage.getItem('removeSpotlight') ? false : true;
-
+  
   constructor(rootStore) {
     this.rootStore = rootStore;
     this.logger = logger.addGroup('cashFlowStore');
@@ -514,10 +514,12 @@ export default class CashFlowStore {
    */
   clearAllData = flow(function* () {
     yield CashFlowEvent.destroyAll();
+    localStorage.clear();
+    this.modalOpen = true;
     this.setEvents([]);
   });
 
   @action closeNarrativeModal() {
     this.modalOpen = !this.modalOpen;
-  } 
+  }
 }

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/stores/strategies-store.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/stores/strategies-store.js
@@ -35,7 +35,7 @@ class StrategiesStore {
       },
       {
         categories: ['expense.housing.rent'],
-        title: 'Split Rent Payments',
+        title: 'Split Rent Payment',
         text: 'Contact your landlord to find out if you could split your payment into two payments per month',
       },
     ],

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/stores/ui-store.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/stores/ui-store.js
@@ -109,7 +109,8 @@ export default class UIStore {
   }
 
   @computed get weekHasNegativeBalance() {
-    return this.weekHasEvents && this.weekEndingBalance < 0;
+    //return this.weekHasEvents && this.weekEndingBalance < 0;
+    return this.weekEndingBalance < 0;
   }
 
   @computed get isRunningAsApp() {

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/stores/ui-store.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/stores/ui-store.js
@@ -109,7 +109,6 @@ export default class UIStore {
   }
 
   @computed get weekHasNegativeBalance() {
-    //return this.weekHasEvents && this.weekEndingBalance < 0;
     return this.weekEndingBalance < 0;
   }
 

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/stores/ui-store.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/stores/ui-store.js
@@ -46,7 +46,6 @@ export default class UIStore {
   @computed get weekRangeText() {
     const start = this.currentWeek.startOf('week');
     const end = this.currentWeek.endOf('week');
-
     return `${start.format('MMMM D')} - ${end.format('MMMM D')}`;
   }
 

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/stores/ui-store.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/stores/ui-store.js
@@ -221,7 +221,7 @@ export default class UIStore {
 
   @action toggleSpotlight = (bool) => {
     this.hasSpotlight = bool;
-  }
+  };
 
   async showInstallPrompt() {
     if (!this.installPromptEvent) return false;

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/calendar/index/day.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/calendar/index/day.js
@@ -37,29 +37,12 @@ function Day({ day, dateFormat = 'D' }) {
 
   if (!eventStore.events.length) return emptyTile(classes);
 
-  const balance = eventStore.getBalanceForDate(day);
-  const weekEndBal = uiStore.weekEndingBalance;
+  const weekEndBal = eventStore.getBalanceForDate(dayjs(day).endOf('week'));
+  console.log('what is the startOf(week)', dayjs(day).startOf('week'));
 
   classes.push({
-    //'pos-balance': balance >= 0 && day.isSameOrAfter(eventStore.earliestEventDate),
-    //'pos-balance': weekEndBal >= 0 && day.isSameOrAfter(uiStore.startOfWeek),
-    'pos-balance':
-      (weekEndBal >= 0 && day.format('YYYY-MM-DD') === uiStore.currentWeek.format('YYYY-MM-DD')) ||
-      (weekEndBal >= 0 && day.format('YYYY-MM-DD') === uiStore.currentWeek.add(1, 'day').format('YYYY-MM-DD')) ||
-      (weekEndBal >= 0 && day.format('YYYY-MM-DD') === uiStore.currentWeek.add(2, 'day').format('YYYY-MM-DD')) ||
-      (weekEndBal >= 0 && day.format('YYYY-MM-DD') === uiStore.currentWeek.add(3, 'day').format('YYYY-MM-DD')) ||
-      (weekEndBal >= 0 && day.format('YYYY-MM-DD') === uiStore.currentWeek.add(4, 'day').format('YYYY-MM-DD')) ||
-      (weekEndBal >= 0 && day.format('YYYY-MM-DD') === uiStore.currentWeek.add(5, 'day').format('YYYY-MM-DD')) ||
-      (weekEndBal >= 0 && day.format('YYYY-MM-DD') === uiStore.currentWeek.add(6, 'day').format('YYYY-MM-DD')),
-
-    'neg-balance':
-      (weekEndBal < 0 && day.format('YYYY-MM-DD') === uiStore.currentWeek.format('YYYY-MM-DD')) ||
-      (weekEndBal < 0 && day.format('YYYY-MM-DD') === uiStore.currentWeek.add(1, 'day').format('YYYY-MM-DD')) ||
-      (weekEndBal < 0 && day.format('YYYY-MM-DD') === uiStore.currentWeek.add(2, 'day').format('YYYY-MM-DD')) ||
-      (weekEndBal < 0 && day.format('YYYY-MM-DD') === uiStore.currentWeek.add(3, 'day').format('YYYY-MM-DD')) ||
-      (weekEndBal < 0 && day.format('YYYY-MM-DD') === uiStore.currentWeek.add(4, 'day').format('YYYY-MM-DD')) ||
-      (weekEndBal < 0 && day.format('YYYY-MM-DD') === uiStore.currentWeek.add(5, 'day').format('YYYY-MM-DD')) ||
-      (weekEndBal < 0 && day.format('YYYY-MM-DD') === uiStore.currentWeek.add(6, 'day').format('YYYY-MM-DD')),
+    'pos-balance': weekEndBal >= 0 && dayjs(day).isBetween(dayjs(day).startOf('week'), dayjs(day).endOf('week')),
+    'neg-balance': weekEndBal < 0 && dayjs(day).isBetween(dayjs(day).startOf('week'), dayjs(day).endOf('week')),
   });
 
   const symbol = eventStore.dateHasEvents(day) ? <div className="calendar__day-symbols">&bull;</div> : null;

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/calendar/index/day.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/calendar/index/day.js
@@ -37,12 +37,15 @@ function Day({ day, dateFormat = 'D' }) {
 
   if (!eventStore.events.length) return emptyTile(classes);
 
-  const weekEndBal = eventStore.getBalanceForDate(dayjs(day).endOf('week'));
-  console.log('what is the startOf(week)', dayjs(day).startOf('week'));
+  const weekEndBal = eventStore.getDay(day.endOf('week')).nonSnapBalance;
 
   classes.push({
-    'pos-balance': weekEndBal >= 0 && dayjs(day).isBetween(dayjs(day).startOf('week'), dayjs(day).endOf('week')),
-    'neg-balance': weekEndBal < 0 && dayjs(day).isBetween(dayjs(day).startOf('week'), dayjs(day).endOf('week')),
+    'pos-balance':
+      weekEndBal >= 0 &&
+      (dayjs(day).startOf('week') || dayjs(day).isBetween(dayjs(day).startOf('week'), dayjs(day).endOf('week'))),
+    'neg-balance':
+      weekEndBal < 0 &&
+      (dayjs(day).startOf('week') || dayjs(day).isBetween(dayjs(day).startOf('week'), dayjs(day).endOf('week'))),
   });
 
   const symbol = eventStore.dateHasEvents(day) ? <div className="calendar__day-symbols">&bull;</div> : null;

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/calendar/index/day.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/calendar/index/day.js
@@ -38,10 +38,28 @@ function Day({ day, dateFormat = 'D' }) {
   if (!eventStore.events.length) return emptyTile(classes);
 
   const balance = eventStore.getBalanceForDate(day);
+  const weekEndBal = uiStore.weekEndingBalance;
 
   classes.push({
-    'pos-balance': balance >= 0 && day.isSameOrAfter(eventStore.earliestEventDate),
-    'neg-balance': balance < 0,
+    //'pos-balance': balance >= 0 && day.isSameOrAfter(eventStore.earliestEventDate),
+    //'pos-balance': weekEndBal >= 0 && day.isSameOrAfter(uiStore.startOfWeek),
+    'pos-balance':
+      (weekEndBal >= 0 && day.format('YYYY-MM-DD') === uiStore.currentWeek.format('YYYY-MM-DD')) ||
+      (weekEndBal >= 0 && day.format('YYYY-MM-DD') === uiStore.currentWeek.add(1, 'day').format('YYYY-MM-DD')) ||
+      (weekEndBal >= 0 && day.format('YYYY-MM-DD') === uiStore.currentWeek.add(2, 'day').format('YYYY-MM-DD')) ||
+      (weekEndBal >= 0 && day.format('YYYY-MM-DD') === uiStore.currentWeek.add(3, 'day').format('YYYY-MM-DD')) ||
+      (weekEndBal >= 0 && day.format('YYYY-MM-DD') === uiStore.currentWeek.add(4, 'day').format('YYYY-MM-DD')) ||
+      (weekEndBal >= 0 && day.format('YYYY-MM-DD') === uiStore.currentWeek.add(5, 'day').format('YYYY-MM-DD')) ||
+      (weekEndBal >= 0 && day.format('YYYY-MM-DD') === uiStore.currentWeek.add(6, 'day').format('YYYY-MM-DD')),
+
+    'neg-balance':
+      (weekEndBal < 0 && day.format('YYYY-MM-DD') === uiStore.currentWeek.format('YYYY-MM-DD')) ||
+      (weekEndBal < 0 && day.format('YYYY-MM-DD') === uiStore.currentWeek.add(1, 'day').format('YYYY-MM-DD')) ||
+      (weekEndBal < 0 && day.format('YYYY-MM-DD') === uiStore.currentWeek.add(2, 'day').format('YYYY-MM-DD')) ||
+      (weekEndBal < 0 && day.format('YYYY-MM-DD') === uiStore.currentWeek.add(3, 'day').format('YYYY-MM-DD')) ||
+      (weekEndBal < 0 && day.format('YYYY-MM-DD') === uiStore.currentWeek.add(4, 'day').format('YYYY-MM-DD')) ||
+      (weekEndBal < 0 && day.format('YYYY-MM-DD') === uiStore.currentWeek.add(5, 'day').format('YYYY-MM-DD')) ||
+      (weekEndBal < 0 && day.format('YYYY-MM-DD') === uiStore.currentWeek.add(6, 'day').format('YYYY-MM-DD')),
   });
 
   const symbol = eventStore.dateHasEvents(day) ? <div className="calendar__day-symbols">&bull;</div> : null;

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/calendar/index/details.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/calendar/index/details.js
@@ -85,6 +85,10 @@ function Details() {
   useLockBodyScroll(modalOpen);
 
   const events = eventStore.getEventsForWeek(uiStore.currentWeek) || [];
+  const startBal = events
+    .filter((x) => x.category === 'income.startingBalance')
+    .map((e) => formatCurrency(e.totalCents / 100));
+
   const endBalanceClasses = clsx('calendar-details__ending-balance', uiStore.weekHasNegativeBalance && 'negative');
 
   return (
@@ -98,17 +102,26 @@ function Details() {
         />
 
         <div className="calendar-details__header-text">
-          <h3>{uiStore.weekRangeText}</h3>
+          <h3>Week of {uiStore.weekRangeText}</h3>
           <div className="calendar-details__starting-balance">
-            Weekly Starting Balance: <span className='balance-amount'>{uiStore.weekStartingBalanceText}</span>
+            Starting Balance:
+            <span className="balance-amount">
+              {events.find((x) => x.category === 'income.startingBalance') ? startBal : uiStore.weekStartingBalanceText}
+            </span>
           </div>
           {!uiStore.weekHasNegativeBalance && !eventStore.hasSnapEvents && (
-            <div className={endBalanceClasses}>Weekly Ending Balance: <span className='balance-amount'>{uiStore.weekEndingBalanceText}</span></div>
+            <div className={endBalanceClasses}>
+              Ending Balance: <span className="balance-amount">{uiStore.weekEndingBalanceText}</span>
+            </div>
           )}
           {!uiStore.weekHasNegativeBalance && eventStore.hasSnapEvents && (
             <div className={endBalanceClasses}>
-              <p>Weekly Ending Balance: <span className='balance-amount'>{uiStore.weekEndingBalanceText}</span></p>
-              <p>Weekly Ending SNAP Balance: <span className='balance-amount'>{uiStore.weekEndingSnapBalanceText}</span></p>
+              <p>
+                Ending Balance: <span className="balance-amount">{uiStore.weekEndingBalanceText}</span>
+              </p>
+              <p>
+                Ending SNAP Balance: <span className="balance-amount">{uiStore.weekEndingSnapBalanceText}</span>
+              </p>
             </div>
           )}
         </div>
@@ -133,14 +146,14 @@ function Details() {
             }
           >
             <p className="m-notification_explanation">
-              Weekly Ending Balance: <span className="neg-ending-balance">{uiStore.weekEndingBalanceText}</span>
+              Ending Balance: <span className="neg-ending-balance">{uiStore.weekEndingBalanceText}</span>
             </p>
           </Notification>
         </div>
       )}
 
       <div className="calendar-details__events-section">
-        <h3 className="calendar-details__events-section-title">Weekly Transactions</h3>
+        <h3 className="calendar-details__events-section-title">Transactions</h3>
 
         <ul className="calendar-details__events-list">
           {events.map((e) => (

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/calendar/index/index.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/calendar/index/index.js
@@ -45,12 +45,12 @@ function Calendar() {
       setNarrativeStep(currentStep);
       setShowModal(true);
     }
-  }
+  };
 
   useEffect(() => {
     uiStore.setPageTitle('myMoney Calendar');
     uiStore.setSubtitle(uiStore.currentMonth.format('MMMM YYYY'));
-    handleModalSession()
+    handleModalSession();
   }, [location, params, uiStore.currentMonth]);
 
   const dayLabels = useMemo(
@@ -85,14 +85,14 @@ function Calendar() {
 
   return (
     <section className="calendar">
-      {showModal && narrativeStep === 'step1' && (
+      {showModal && narrativeStep === 'step1' &&
         <NarrativeModal
           showModal={showModal}
           handleOkClick={handleToggleModal}
           copy={narrativeCopy.step1}
           step={narrativeStep}
         />
-      )}
+      }
       {showModal && narrativeStep === 'step2' && 
         <NarrativeModal showModal={showModal}
                         handleOkClick={handleToggleModal}

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/calendar/index/index.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/calendar/index/index.js
@@ -41,17 +41,16 @@ function Calendar() {
     if (visited && enteredData === 'subsequent') {
       setShowModal(false);
     } else {
-      let currentStep = visited && enteredData === 'initial' ? 'step2' : 'step1';
-
+      let currentStep = (visited && enteredData === 'initial') ? 'step2' : 'step1';
       setNarrativeStep(currentStep);
       setShowModal(true);
     }
-  };
+  }
 
   useEffect(() => {
     uiStore.setPageTitle('myMoney Calendar');
     uiStore.setSubtitle(uiStore.currentMonth.format('MMMM YYYY'));
-    handleModalSession();
+    handleModalSession()
   }, [location, params, uiStore.currentMonth]);
 
   const dayLabels = useMemo(
@@ -74,7 +73,7 @@ function Calendar() {
       localStorage.setItem('enteredData', 'subsequent');
     }
     if (!localStorage.getItem('removeSpotlight')) {
-      localStorage.setItem('removeSpotlight', true);
+      localStorage.setItem('removeSpotlight', true)
       eventStore.closeNarrativeModal();
     }
     setShowModal(!showModal);
@@ -94,14 +93,13 @@ function Calendar() {
           step={narrativeStep}
         />
       )}
-      {showModal && narrativeStep === 'step2' && (
-        <NarrativeModal
-          showModal={showModal}
-          handleOkClick={handleToggleModal}
-          copy={narrativeCopy.step2}
-          step={narrativeStep}
+      {showModal && narrativeStep === 'step2' && 
+        <NarrativeModal showModal={showModal}
+                        handleOkClick={handleToggleModal}
+                        copy={narrativeCopy.step2}
+                        step={narrativeStep}
         />
-      )}
+      }
       <header className="calendar__header">
         <IconButton
           className="calendar__nav-button"

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/calendar/index/index.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/calendar/index/index.js
@@ -45,12 +45,12 @@ function Calendar() {
       setNarrativeStep(currentStep);
       setShowModal(true);
     }
-  };
+  }
 
   useEffect(() => {
     uiStore.setPageTitle('myMoney Calendar');
     uiStore.setSubtitle(uiStore.currentMonth.format('MMMM YYYY'));
-    handleModalSession();
+    handleModalSession()
   }, [location, params, uiStore.currentMonth]);
 
   const dayLabels = useMemo(
@@ -93,13 +93,13 @@ function Calendar() {
           step={narrativeStep}
         />
       )}
-      {showModal && narrativeStep === 'step2' && (
+      {showModal && narrativeStep === 'step2' && 
         <NarrativeModal showModal={showModal}
                         handleOkClick={handleToggleModal}
                         copy={narrativeCopy.step2}
                         step={narrativeStep}
         />
-      )}
+      }
       <header className="calendar__header">
         <IconButton
           className="calendar__nav-button"

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/calendar/index/index.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/calendar/index/index.js
@@ -41,16 +41,21 @@ function Calendar() {
     if (visited && enteredData === 'subsequent') {
       setShowModal(false);
     } else {
+<<<<<<< HEAD
       let currentStep = (visited && enteredData === 'initial') ? 'step2' : 'step1';
+=======
+      let currentStep = visited && enteredData === 'initial' ? 'step2' : 'step1';
+
+>>>>>>> 655a87903... weeks are changing colors correctly
       setNarrativeStep(currentStep);
       setShowModal(true);
     }
-  }
+  };
 
   useEffect(() => {
     uiStore.setPageTitle('myMoney Calendar');
     uiStore.setSubtitle(uiStore.currentMonth.format('MMMM YYYY'));
-    handleModalSession()
+    handleModalSession();
   }, [location, params, uiStore.currentMonth]);
 
   const dayLabels = useMemo(
@@ -99,7 +104,7 @@ function Calendar() {
                         copy={narrativeCopy.step2}
                         step={narrativeStep}
         />
-      }
+      )}
       <header className="calendar__header">
         <IconButton
           className="calendar__nav-button"

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/calendar/index/index.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/calendar/index/index.js
@@ -41,12 +41,7 @@ function Calendar() {
     if (visited && enteredData === 'subsequent') {
       setShowModal(false);
     } else {
-<<<<<<< HEAD
       let currentStep = (visited && enteredData === 'initial') ? 'step2' : 'step1';
-=======
-      let currentStep = visited && enteredData === 'initial' ? 'step2' : 'step1';
-
->>>>>>> 655a87903... weeks are changing colors correctly
       setNarrativeStep(currentStep);
       setShowModal(true);
     }
@@ -98,7 +93,7 @@ function Calendar() {
           step={narrativeStep}
         />
       )}
-      {showModal && narrativeStep === 'step2' && 
+      {showModal && narrativeStep === 'step2' && (
         <NarrativeModal showModal={showModal}
                         handleOkClick={handleToggleModal}
                         copy={narrativeCopy.step2}

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/calendar/index/index.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/calendar/index/index.js
@@ -36,22 +36,22 @@ function Calendar() {
 
   const handleModalSession = () => {
     let visited = localStorage.getItem('visitedPage'),
-        enteredData = localStorage.getItem('enteredData');
+      enteredData = localStorage.getItem('enteredData');
 
     if (visited && enteredData === 'subsequent') {
       setShowModal(false);
     } else {
-      let currentStep = (visited && enteredData === 'initial') ? 'step2' : 'step1';
+      let currentStep = visited && enteredData === 'initial' ? 'step2' : 'step1';
 
-      setNarrativeStep(currentStep)
+      setNarrativeStep(currentStep);
       setShowModal(true);
     }
-  }
+  };
 
   useEffect(() => {
     uiStore.setPageTitle('myMoney Calendar');
     uiStore.setSubtitle(uiStore.currentMonth.format('MMMM YYYY'));
-    handleModalSession()
+    handleModalSession();
   }, [location, params, uiStore.currentMonth]);
 
   const dayLabels = useMemo(
@@ -74,8 +74,8 @@ function Calendar() {
       localStorage.setItem('enteredData', 'subsequent');
     }
     if (!localStorage.getItem('removeSpotlight')) {
-      localStorage.setItem('removeSpotlight', true)
-      eventStore.closeNarrativeModal()
+      localStorage.setItem('removeSpotlight', true);
+      eventStore.closeNarrativeModal();
     }
     setShowModal(!showModal);
   };
@@ -86,20 +86,22 @@ function Calendar() {
 
   return (
     <section className="calendar">
-      {showModal && narrativeStep === 'step1' &&
-        <NarrativeModal showModal={showModal}
-                        handleOkClick={handleToggleModal}
-                        copy={narrativeCopy.step1}
-                        step={narrativeStep}
+      {showModal && narrativeStep === 'step1' && (
+        <NarrativeModal
+          showModal={showModal}
+          handleOkClick={handleToggleModal}
+          copy={narrativeCopy.step1}
+          step={narrativeStep}
         />
-      }
-      { showModal && narrativeStep === 'step2' &&
-        <NarrativeModal showModal={showModal}
-                        handleOkClick={handleToggleModal}
-                        copy={narrativeCopy.step2}
-                        step={narrativeStep}
+      )}
+      {showModal && narrativeStep === 'step2' && (
+        <NarrativeModal
+          showModal={showModal}
+          handleOkClick={handleToggleModal}
+          copy={narrativeCopy.step2}
+          step={narrativeStep}
         />
-      }
+      )}
       <header className="calendar__header">
         <IconButton
           className="calendar__nav-button"

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/money-on-hand/start.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/money-on-hand/start.js
@@ -8,21 +8,22 @@ import hero from 'img/Hero_2.png';
 export default function Start() {
   useScrollToTop();
 
-
   return (
     <>
       <Hero
-        title="MyMoney Calendar"
+        title="myMoney Calendar"
         subtitle="See how your money flows from week to week and learn how to avoid coming up short."
         image={hero}
-        alt="MyMoney Calendar"
+        alt="myMoney Calendar"
       />
       <br />
       <div className="m-hero_subhead">
         <p>Enter your income, expenses, and cash-on-hand to build your calendar.</p>
         <p>It's okay to estimate.</p>
 
-        <ButtonLink icon={arrowRight} iconSide="right" to="/money-on-hand/sources">Get Started</ButtonLink>
+        <ButtonLink icon={arrowRight} iconSide="right" to="/money-on-hand/sources">
+          Get Started
+        </ButtonLink>
       </div>
     </>
   );

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/money-on-hand/summary.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/money-on-hand/summary.js
@@ -58,7 +58,7 @@ function Summary() {
 
             return (
               <li key={`funding-src-${idx}`} className="funding-source">
-                <span className="funding-source__name">{name}:</span>{' '}
+                <span className="funding-source__name">{name}:</span>
                 <span className="funding-source__balance">{formatCurrency(balance / 100)}</span>
               </li>
             );

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/more/export.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/more/export.js
@@ -15,11 +15,13 @@ function Export() {
   return (
     <section className={bem()}>
       <header className={bem('header')}>
-        <h1 className={bem('app-title')}>MyMoney Calendar</h1>
+        <h1 className={bem('app-title')}>myMoney Calendar</h1>
         <h2 className={bem('section-title')}>Save {dataType}</h2>
       </header>
 
-      <ButtonLink to="/more" variant="secondary">Back</ButtonLink>
+      <ButtonLink to="/more" variant="secondary">
+        Back
+      </ButtonLink>
     </section>
   );
 }

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/more/index.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/more/index.js
@@ -25,36 +25,24 @@ function More() {
   return (
     <section className={bem()}>
       <header className={bem('header')}>
-        <h1 className={bem('app-title')}>MyMoney Calendar</h1>
+        <h1 className={bem('app-title')}>myMoney Calendar</h1>
         <h2 className={bem('section-title')}>More Options</h2>
       </header>
 
       <main className={bem('main')}>
         <ul className={bem('actions')}>
           <li className={bem('actions-item')}>
-            <ButtonLink
-              fullWidth
-              variant="primary"
-              to="/more/export/strategies"
-            >
+            <ButtonLink fullWidth variant="primary" to="/more/export/strategies">
               Save Strategies
             </ButtonLink>
           </li>
           <li className={bem('actions-item')}>
-            <ButtonLink
-              fullWidth
-              variant="primary"
-              to="/more/export/calendar"
-            >
+            <ButtonLink fullWidth variant="primary" to="/more/export/calendar">
               Save Calendar
             </ButtonLink>
           </li>
           <li className={bem('actions-item')}>
-            <Button
-              fullWidth
-              variant="warning"
-              onClick={() => toggleClearDataModal(true)}
-            >
+            <Button fullWidth variant="warning" onClick={() => toggleClearDataModal(true)}>
               Clear My Data
             </Button>
           </li>

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/strategies/fix-it/index.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/strategies/fix-it/index.js
@@ -97,12 +97,11 @@ function FixItStrategies() {
   var weekExpenses = negativeFilter.reduce((acc, event) => acc + event.total, 0);
   return (
     <section className="strategies">
-      { showModal && 
+      {showModal && (
         <NarrativeModal showModal={showModal}
                         handleOkClick={handleToggleModal}
-                        copy={narrativeCopy.step3}
-        />
-      }
+                        copy={narrativeCopy.step3} />
+      )}
       <header className="strategies-header">
         <h2 className="strategies-header__title">Fix-It Strategies</h2>
         {strategies.fixItResults.length ? (
@@ -125,11 +124,11 @@ function FixItStrategies() {
                   <div className="fixit-header__comment-value">{uiStore.weekStartingBalanceText}</div>
                 </div>
                 <div className="fixit-header__comment">
-                  <div>Weekly Income: </div>
+                  <div>Income: </div>
                   <div className="fixit-header__comment-value">{formatCurrency(weekIncome)}</div>
                 </div>
                 <div className="fixit-header__comment">
-                  <div>Weekly Expense:</div>
+                  <div>Expense:</div>
                   <div className="fixit-header__comment-value">{formatCurrency(weekExpenses)}</div>
                 </div>
               </div>
@@ -141,10 +140,10 @@ function FixItStrategies() {
             </CardGroup>
           </div>
         ) : (
-          <p>
-            <em>There are no strategy recommendations for this week</em>
-          </p>
-        )}
+            <p>
+              <em>There are no strategy recommendations for this week</em>
+            </p>
+          )}
       </header>
       <div>{strategies.fixItResults.length > 0 && <StrategyCards results={strategies.fixItResults} />}</div>
       <div>


### PR DESCRIPTION
Client wanted the following:

- if the _week ending balance_ is equal to $0 or above, all days in the week should be green
- if the _week ending balance_ is below $0, then all days in the week should be red

closing #88 



## Changes

- changed logic in the day.js file


## How to test this PR

1. open this branch locally and run the _gulp scripts:moneytools
2.  at $100 _starting balance_.
3.  View calendar to see that the whole calendar is green.
4. add an $300 expense in the second week.  View calendar to see that the whole second week is green.
5.  add a one time income in the third week.  View calendar to see that the third week is green again.
6.  Test other scenarios as you see fit.


## Screenshots

<img width="150" alt="Screen Shot 2020-07-03 at 5 13 28 PM" src="https://user-images.githubusercontent.com/34319929/86497941-98190a80-bd51-11ea-8971-246947dcf6bd.png">


