### PR TITLE
Jb fix it balance bug

### DIFF
--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/stores/cash-flow-store.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/stores/cash-flow-store.js
@@ -301,7 +301,6 @@ export default class CashFlowStore {
   getPositiveEventsForWeek(date) {
     date = toDayJS(date).startOf('week');
     const positiveEvents = this.eventsByWeek.get(date.valueOf());
-
     return positiveEvents;
   }
 

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/calendar/add/form.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/calendar/add/form.js
@@ -49,10 +49,6 @@ function Form() {
     handleModalSession();
   }, [])
 
-  useEffect(() => {
-    handleModalSession();
-  }, [])
-
   // Toggle bottom nav bar when inputs are focused, to prevent it from obscuring text on mobile screens:
   const focusHandler = useCallback(
     (evt) => {

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/strategies/fix-it/index.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/strategies/fix-it/index.js
@@ -93,7 +93,7 @@ function FixItStrategies() {
   const events = eventStore.getPositiveEventsForWeek(uiStore.currentWeek) || [];
   var positiveFilter = events.filter((event) => event.total > 0);
   var initialBalance = positiveFilter.find((event) => event.category === 'income.startingBalance');
-  var positiveEvents = positiveFilter.filter((event) => event.category !== 'income.startingBalance');
+  var positiveEvents = positiveFilter.filter((event) => (event.category !== 'income.startingBalance' && event.category !== 'income.benefits.snap'));
   var weekIncome = positiveEvents.reduce((acc, event) => acc + event.total, 0);
   var negativeFilter = events.filter((event) => event.total < 0);
   var weekExpenses = negativeFilter.reduce((acc, event) => acc + event.total, 0);

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/strategies/fix-it/index.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/strategies/fix-it/index.js
@@ -92,7 +92,9 @@ function FixItStrategies() {
 
   const events = eventStore.getPositiveEventsForWeek(uiStore.currentWeek) || [];
   var positiveFilter = events.filter((event) => event.total > 0);
-  var weekIncome = positiveFilter.reduce((acc, event) => acc + event.total, 0);
+  var initialBalance = positiveFilter.find((event) => event.category === 'income.startingBalance');
+  var positiveEvents = positiveFilter.filter((event) => event.category !== 'income.startingBalance');
+  var weekIncome = positiveEvents.reduce((acc, event) => acc + event.total, 0);
   var negativeFilter = events.filter((event) => event.total < 0);
   var weekExpenses = negativeFilter.reduce((acc, event) => acc + event.total, 0);
   return (
@@ -121,7 +123,7 @@ function FixItStrategies() {
               <div className="fixit-header">
                 <div className="fixit-header__comment">
                   <div>Starting Balance:</div>
-                  <div className="fixit-header__comment-value">{uiStore.weekStartingBalanceText}</div>
+                  <div className="fixit-header__comment-value">{initialBalance ? formatCurrency(initialBalance.total) : uiStore.weekStartingBalanceText}</div>
                 </div>
                 <div className="fixit-header__comment">
                   <div>Income: </div>


### PR DESCRIPTION
Closes #98 
Closes #99 

Since both of the issues are largely handled in the same file am including them in one PR.

This will update how data is presented on the Fix-It summary page.

If a user goes into the red on their first week. The initial balance they start with will not be shown as income, but rather as the weekly starting balance in the summary

If a user has SNAP income that week, it will not be counted as general income on the Fix-It summary page since it is already  displayed in its own separate area.

### To Test:
- Visit dev: https://cfgov-refresh-dev.herokuapp.com/mmt-my-money-calendar
- Set up initial balance of $500
- Add rent expense for same week of $1000
- Add SNAP benefit for same week of $300
- Click on Fix-It
- Summary should look like the below:
<img width="567" alt="Screen Shot 2020-07-31 at 4 11 00 PM" src="https://user-images.githubusercontent.com/21065244/89081414-7dce4e80-d348-11ea-98a7-0195c36a1497.png">

