### PR TITLE
Mm/disable grocery strategy

### DIFF
--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/stores/models/categories.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/stores/models/categories.js
@@ -393,12 +393,12 @@ export const Categories = new CategoryTree({
         icon: icons.groceries,
         recurrenceTypes: ['weekly', 'monthly'],
         hasBill: false,
-        strategy: {
+        /* strategy: {
           id: 'reduceGroceryExpenses',
           title: 'Reduce your Grocery Expenses',
           body:
             'Using coupons and buying groceries and supplies in bulk with other family or friends can help reduce your grocery costs and put more money in your budget.',
-        },
+        }, */
       },
     },
     emergencySavings: {

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/stores/models/categories.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/stores/models/categories.js
@@ -393,12 +393,6 @@ export const Categories = new CategoryTree({
         icon: icons.groceries,
         recurrenceTypes: ['weekly', 'monthly'],
         hasBill: false,
-        /* strategy: {
-          id: 'reduceGroceryExpenses',
-          title: 'Reduce your Grocery Expenses',
-          body:
-            'Using coupons and buying groceries and supplies in bulk with other family or friends can help reduce your grocery costs and put more money in your budget.',
-        }, */
       },
     },
     emergencySavings: {

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/stores/models/categories.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/stores/models/categories.js
@@ -393,6 +393,12 @@ export const Categories = new CategoryTree({
         icon: icons.groceries,
         recurrenceTypes: ['weekly', 'monthly'],
         hasBill: false,
+        /* strategy: {
+          id: 'reduceGroceryExpenses',
+          title: 'Reduce your Grocery Expenses',
+          body:
+            'Using coupons and buying groceries and supplies in bulk with other family or friends can help reduce your grocery costs and put more money in your budget.',
+        }, */
       },
     },
     emergencySavings: {

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/stores/strategies-store.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/stores/strategies-store.js
@@ -76,7 +76,7 @@ class StrategiesStore {
           'expense.transportation.publicTransportation',
           'expense.transportation.gas',
           'expense.food.eatingOut',
-          'expense.food.groceries',
+          /* 'expense.food.groceries', */
           'expense.personal.clothing',
           'expense.personal.personalCare',
           'expense.personal.funMoney',


### PR DESCRIPTION
<!-- Enter an explanation of what the pull request does and why. -->

--- Client requested to temporarily disallow the grocery strategy for fix-it algorithm as well as general strategy algorithm.


## Removals

- commented json elements under 'groceries' in categories.js
- commented 'expense.food.groceries' in strategies-store.js



## How to test this PR

1. Open app locally.
2. Add $0 starting balance.
3. Note that there is a 2 superscript on the strategies icon on the _bottom nav_.
3. Add $100 weekly groceries on Fridays.
4.  Note that the superscript on the strategies icon is still '2'. 
5.  Tap the icon and see that no grocery strategy shows under the _General Strategies_ area.
6.  Tap the _Fix-It_ button in any red week.
7.   Note that there is no 'grocery' strategy in the Fix-it area.
8.  Add a 'clothing' expense for $75 in the first red week.  This means that there are two expenses in the _non due-date_ category in the same week.  Previously, you would see the 'grocery' fix-it strategy because it is the higher value _non due-date_ expense.  Now, you see the 'clothing' fix-it strategy because the 'grocery' strategy has been commented out.


## Screenshots

![Screen Shot 2020-08-02 at 12 38 19 PM](https://user-images.githubusercontent.com/34319929/89127644-14238100-d4bd-11ea-92ca-d5038feac22e.png)

