### PR TITLE
moved location of field

### DIFF
--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/calendar/add/form.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/calendar/add/form.js
@@ -202,34 +202,6 @@ function Form() {
               placeholder={`For example: ${category.name}`}
             />
 
-            <CurrencyField
-              id="totalCents"
-              name="totalCents"
-              label="Pay Amount"
-              onChange={formik.handleChange}
-              onFocus={focusHandler}
-              onBlur={blurHandler(formik.handleBlur)}
-              value={formik.values.totalCents}
-              errors={formik.errors.totalCents}
-              touched={formik.touched.totalCents}
-              tabIndex="0"
-              required
-            />
-
-            <DateField
-              id="dateTime"
-              name="dateTime"
-              label={eventType === 'expense' ? 'Due Date' : 'Pay Date'}
-              onChange={formik.handleChange}
-              onFocus={focusHandler}
-              onBlur={blurHandler(formik.handleBlur)}
-              value={formik.values.dateTime || ''}
-              errors={formik.errors.dateTime}
-              touched={formik.touched.dateTime}
-              tabIndex="0"
-              required
-            />
-
             <Checkbox
               id="recurs"
               name="recurs"
@@ -281,6 +253,36 @@ function Form() {
                 />
               </>
             )}
+
+            <CurrencyField
+              id="totalCents"
+              name="totalCents"
+              label="Pay Amount"
+              onChange={formik.handleChange}
+              onFocus={focusHandler}
+              onBlur={blurHandler(formik.handleBlur)}
+              value={formik.values.totalCents}
+              errors={formik.errors.totalCents}
+              touched={formik.touched.totalCents}
+              tabIndex="0"
+              required
+            />
+
+            <DateField
+              id="dateTime"
+              name="dateTime"
+              label={eventType === 'expense' ? 'Due Date' : 'Pay Date'}
+              onChange={formik.handleChange}
+              onFocus={focusHandler}
+              onBlur={blurHandler(formik.handleBlur)}
+              value={formik.values.dateTime || ''}
+              errors={formik.errors.dateTime}
+              touched={formik.touched.dateTime}
+              tabIndex="0"
+              required
+            />
+
+            
 
             <Button fullWidth disabled={!formik.dirty && !formik.isValid} type="submit" tabIndex="0">
               Save


### PR DESCRIPTION
Client wanted to move location of recurrence/frequency options to above the amount field.  This request is linked to #204 on Money-tools project board.



## Changes

- Moved location of checkbox and associated fields on the form.js file


## How to test this PR

1. open app and clear cache.
2. complete _Money-on-Hand_ screens and arrive at the _Calendar View_.
3.  Add a job.  Note that the location of the _Recurring_ checkbox  is right under the _Description_ (It was, previously, further down the page).
4. Add frequency of _weekly_.
5.  Fill in the rest of the fields as you like and tap _Save_.
6.  Note, does the job appear as it had in the past?  There should be a dot each week on the day that the transaction is supposed to occur.  Also, the _Job_ transaction should appear on the _transaction list_ below the calendar for each week.
7.  Repeat this for an expense.  The _Recurring_ checkbox and other options should appear under the _Description_ field.

## Screenshots

<img width="150" alt="Screen Shot 2020-08-12 at 10 42 45 AM" src="https://user-images.githubusercontent.com/34319929/90032575-86018480-dc8c-11ea-8c47-9da0add60673.png">
<img width="150" alt="Screen Shot 2020-08-12 at 10 42 59 AM" src="https://user-images.githubusercontent.com/34319929/90032576-86018480-dc8c-11ea-887e-8adc55de248b.png">
