### PR TITLE
mm/revised fix-it page titles

### DIFF
--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/css/components/strategies.less
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/css/components/strategies.less
@@ -33,6 +33,7 @@
 
 .strategies-header__week-range {
   text-align: center;
+  font-weight: 600;
 }
 
 .fixit-header {

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/strategies/fix-it/index.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/strategies/fix-it/index.js
@@ -105,10 +105,10 @@ function FixItStrategies() {
                         copy={narrativeCopy.step3} />
       )}
       <header className="strategies-header">
-        <h2 className="strategies-header__title">Fix-It Strategies</h2>
+       
         {strategies.fixItResults.length ? (
           <div className="strategy-cards">
-            <h3 className="strategies-header__week-range">Week of {uiStore.weekRangeText}</h3>
+            <h2 className="strategies-header__week-range">Week of {uiStore.weekRangeText}</h2>
             <CardGroup columns={2}>
               <div className="fixit-header">
                 <div className="fixit-header__line-first">
@@ -147,6 +147,7 @@ function FixItStrategies() {
             </p>
           )}
       </header>
+      <h2 className="strategies-header__title">Fix-It Strategies</h2>
       <div>{strategies.fixItResults.length > 0 && <StrategyCards results={strategies.fixItResults} />}</div>
       <div>
         <Strategies />

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/strategies/index.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/strategies/index.js
@@ -31,14 +31,14 @@ function Strategies() {
 
   return (
     <section className="strategies">
-      <header className="strategies-header">
+      {/* <header className="strategies-header">
         <h2 className="strategies-header__title">General Strategies to Improve Cash Flow</h2>
 
         <p className="strategies-header__intro">
           The strategies below are tailored to the specific expenses and income in your budget. Commit to implementing
           one or two of them for the coming month and see if your cash flow improves.
         </p>
-      </header>
+      </header> */}
       {strategiesStore.strategyResults.length > 0 && <StrategyCards results={strategiesStore.strategyResults} />}
     </section>
   );

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/strategies/index.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/strategies/index.js
@@ -31,14 +31,6 @@ function Strategies() {
 
   return (
     <section className="strategies">
-      {/* <header className="strategies-header">
-        <h2 className="strategies-header__title">General Strategies to Improve Cash Flow</h2>
-
-        <p className="strategies-header__intro">
-          The strategies below are tailored to the specific expenses and income in your budget. Commit to implementing
-          one or two of them for the coming month and see if your cash flow improves.
-        </p>
-      </header> */}
       {strategiesStore.strategyResults.length > 0 && <StrategyCards results={strategiesStore.strategyResults} />}
     </section>
   );


### PR DESCRIPTION
Client wanted several changes to the header of the Fix-it Strategies.  This pertains to #206 in the Money-Tools project board.


## Changes

- adjusted formatting of headers in strategies.less file
- moved headers in the /strategies/fix-it/index.js file


## How to test this PR

1.  Open and clear application cache.
2.  Complete the _Money-on-hand_ screens (do not need starting balance).
3.  Once on the _Calendar View_, add an expense such that you get a _red_ week.
4. Tap the red week and go to the _Fix-It_ screen.
5. Note that the _week header_, the change in location of the _Fix-it header_ and the removal of the _General Strategies header_ and accompanying copy.  It should look like the screenshot below.


## Screenshots

<img width="200" alt="Screen Shot 2020-08-12 at 4 23 20 PM" src="https://user-images.githubusercontent.com/34319929/90064125-4f416380-dcb8-11ea-9c44-bd6cc57aeff2.png">

