### PR TITLE
mm/format selected week

### DIFF
--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/css/components/calendar.less
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/css/components/calendar.less
@@ -1,7 +1,8 @@
 @cols: 7;
 @gap: 10px;
 @inactiveMonthColor: #a4a4a4;
-@positiveColor: #cbf0b6;
+/* @positiveColor: #cbf0b6; */
+@positiveColor: #fff;
 @negativeColor: #f0b6b6;
 @breakpointSm: 450px;
 @breakpointMed: 500px;
@@ -79,6 +80,7 @@
       .calendar__day {
         border-top: @currentWeekBorder;
         border-bottom: @currentWeekBorder;
+        background-color:orange;
 
         &:first-of-type {
           border-left: @currentWeekBorder;

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/css/components/calendar.less
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/css/components/calendar.less
@@ -1,9 +1,12 @@
 @cols: 7;
 @gap: 10px;
 @inactiveMonthColor: #a4a4a4;
-/* @positiveColor: #cbf0b6; */
-@positiveColor: #fff;
-@negativeColor: #f0b6b6;
+@positiveColorSelected: #cbf0b6;
+@negativeColorSelected: #f0b6b6;
+@positiveCalendarColor: #fff;
+@negativeCalendarColor: #f9e0e0;
+@positiveColor: #cbf0b6;
+@negativeColor: #f9e0e0;
 @breakpointSm: 450px;
 @breakpointMed: 500px;
 @breakpointLg: 900px;
@@ -80,7 +83,14 @@
       .calendar__day {
         border-top: @currentWeekBorder;
         border-bottom: @currentWeekBorder;
-        background-color:orange;
+        &.pos-balance {
+          background-color: #20aa3f;
+          color: #fff;
+        }
+        &.neg-balance {
+          background-color: #d14124;
+          color: #fff;
+        }
 
         &:first-of-type {
           border-left: @currentWeekBorder;
@@ -124,13 +134,13 @@
     }
 
     &.pos-balance {
-      background-color: @positiveColor;
-      border-color: @positiveColor;
+      background-color: @positiveCalendarColor;
+      border-color: @positiveCalendarColor;
     }
 
     &.neg-balance {
-      background-color: @negativeColor;
-      border-color: @negativeColor;
+      background-color: @negativeCalendarColor;
+      border-color: @negativeCalendarColor;
     }
 
     &.selected {


### PR DESCRIPTION
Client wishes to adjust the formatting I want to clearly and easily understand which week I am focused on.


## Changes

-  added formatting to calendar.less


## How to test this PR

- Open app and clear local cache
- Add $100 for Starting Balance
- In week after starting week, add transactions in the following categories:
   - rent: $100 (housing category)
   - electricity: $80 (due date category)
   - clothing: $50. (non-due date category)
   - Tap the _Starting Balance_ week.  It should be dark green.  The next week should be pale red.  The last week of the month should be white.  This is a green week but, if it is not highlighted, the color should be white.  
   - Tap the week after the _Starting Balance_.  This is a red week.  When it is highlighted, it should be dark red and the _Starting Balance_ should turn white.


## Screenshots

<img width="200" alt="Screen Shot 2020-08-19 at 12 16 09 PM" src="https://user-images.githubusercontent.com/34319929/90661963-cecdb600-e215-11ea-87de-701382826d7d.png">
<img width="200" alt="Screen Shot 2020-08-19 at 12 15 57 PM" src="https://user-images.githubusercontent.com/34319929/90661964-cf664c80-e215-11ea-9f09-52da0d84f058.png">