### PR TITLE
mm/improved rent strategy logic and changed format of calendar view

### DIFF
--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/css/components/calendar.less
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/css/components/calendar.less
@@ -1,18 +1,21 @@
 @cols: 7;
 @gap: 10px;
-@inactiveMonthColor: #a4a4a4;
-@positiveColorSelected: #cbf0b6;
-@negativeColorSelected: #f0b6b6;
+@inactiveMonthColor: #e7e8e9;
+@selectedMonthColor: #101820;
+@positiveColorSelected: #e2efd8;
+@negativeColorSelected: #d14124;
 @positiveCalendarColor: #fff;
 @negativeCalendarColor: #f9e0e0;
-@positiveColor: #cbf0b6;
-@negativeColor: #f9e0e0;
+@positiveColor: #20aa3f;
+@positiveNotificationColor: #f0f8eb;
+@negativeColor: #fbefec;
 @breakpointSm: 450px;
 @breakpointMed: 500px;
 @breakpointLg: 900px;
 @breakpointHiDPI: 1.5dppx;
 @symbolSize: 24px;
 @currentWeekBorder: 2px solid @inactiveMonthColor;
+@selectedWeekBorder: 3px solid @selectedMonthColor;
 
 .calendar {
   display: flex;
@@ -81,23 +84,23 @@
 
     &.selected {
       .calendar__day {
-        border-top: @currentWeekBorder;
-        border-bottom: @currentWeekBorder;
-        &.pos-balance {
-          background-color: #20aa3f;
-          color: #fff;
-        }
+        border-top: @selectedWeekBorder;
+        border-bottom: @selectedWeekBorder;
+       /*  &.pos-balance {
+          font-style:italic;
+        } */
         &.neg-balance {
           background-color: #d14124;
           color: #fff;
+          font-weight:600;
         }
 
         &:first-of-type {
-          border-left: @currentWeekBorder;
+          border-left: @selectedWeekBorder;
         }
 
         &:last-of-type {
-          border-right: @currentWeekBorder;
+          border-right: @selectedWeekBorder;
         }
       }
     }
@@ -141,6 +144,7 @@
     &.neg-balance {
       background-color: @negativeCalendarColor;
       border-color: @negativeCalendarColor;
+      font-weight: 675;
     }
 
     &.selected {
@@ -232,7 +236,7 @@
       padding: 5px;
     }
     &_save-button {
-      background-color: @green;
+      background-color: @positiveColor;
       color: #fff;
       display: block;
       font-weight: bold;
@@ -242,7 +246,7 @@
     }
 
     &__savings {
-      background: lighten(@positiveColor, 10%);
+      background: @positiveNotificationColor;
       border-color:@green;
        
       .cf-icon-svg {
@@ -325,6 +329,7 @@
 
     &.-negative-balance {
       border: 1px solid @red;
+      font-weight:600;
     }
   }
 

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/css/components/strategies.less
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/css/components/strategies.less
@@ -26,7 +26,7 @@
 }
 
 .general {
-  width:1.1875em;
+  width:25px;
 }
 
 .m-card {

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/stores/cash-flow-store.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/stores/cash-flow-store.js
@@ -356,11 +356,16 @@ export default class CashFlowStore {
    */
   saveEvent = flow(function* (params, updateRecurrences = false) {
     let event;
+
     let recurrenceTypeChanged = false;
 
     if (params.id) {
       this.logger.debug('updating existing event %O', params);
       event = this.getEvent(params.id);
+
+      if (event && event.category.includes('housing')) {
+        event.setHideFixItStrategy(true);
+      }
 
       if (event.recurrenceType !== params.recurrenceType) {
         recurrenceTypeChanged = true;

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/stores/strategies-store.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/stores/strategies-store.js
@@ -9,7 +9,7 @@ class StrategiesStore {
     'expense.personal.coronavirus': {
       id: 'coronaVirus',
       icon1: icons.coronaVirus1,
-      title: 'Protect Your Finances from COVID-19',
+      title: 'COVID-19',
       body:
         'Get information about protecting your financial health.',
       link: {

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/calendar/add/form.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/calendar/add/form.js
@@ -162,7 +162,6 @@ function Form() {
           payday2: paydaySchema,
         })}
         onSubmit={(values) => {
-          if (!values.name) values.name = category.name;
 
           logger.debug('Event form submission: %O', values);
           logger.debug('Category %s', categoryPath);
@@ -190,6 +189,8 @@ function Form() {
           } else {
             localStorage.setItem('enteredData', 'subsequent')
           }
+
+          
 
           return saveEvent(values);
         }}

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/calendar/add/form.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/calendar/add/form.js
@@ -162,6 +162,7 @@ function Form() {
           payday2: paydaySchema,
         })}
         onSubmit={(values) => {
+          if (!values.name) values.name = category.name;
 
           logger.debug('Event form submission: %O', values);
           logger.debug('Category %s', categoryPath);

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/strategies/fix-it/index.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/strategies/fix-it/index.js
@@ -20,13 +20,17 @@ const FixItButton = ({ result }) => {
   const history = useHistory();
   const buttonAction = useCallback(
     async (evt) => {
+
       evt.preventDefault();
 
       // Hide "Split Payment" fix-it strategies for this event once the user clicks Fix It once
-      if (result.event && result.event.category.includes('housing')) {
-        result.event.setHideFixItStrategy(true);
-        await eventStore.saveEvent(result.event, true);
-      }
+      // missy commented this out
+      //if (result.event && result.event.category.includes('housing')) {
+       /*  result.event.setHideFixItStrategy(true);
+        await eventStore.saveEvent(result.event, true); */
+      //}
+
+      //console.log('Index.js: FixItButton', result.event);
 
       history.push(href);
     },

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/strategies/fix-it/index.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/strategies/fix-it/index.js
@@ -23,15 +23,6 @@ const FixItButton = ({ result }) => {
 
       evt.preventDefault();
 
-      // Hide "Split Payment" fix-it strategies for this event once the user clicks Fix It once
-      // missy commented this out
-      //if (result.event && result.event.category.includes('housing')) {
-       /*  result.event.setHideFixItStrategy(true);
-        await eventStore.saveEvent(result.event, true); */
-      //}
-
-      //console.log('Index.js: FixItButton', result.event);
-
       history.push(href);
     },
     [result.event, href]


### PR DESCRIPTION
Fix-it Strategy for _Rent_ was disappearing after only one view, even though no changes were made.  Client also requested revisions to formatting for accessibility reasons.  Also, updated some of the colors to be aligned with the CFPB Design standards.

## Changes

- **_Rent Strategy Logic_**:  Prior to the change, when a user tapped on the _Fix-It_ button, the **hideFixItStrategy** flag for the _Rent_ strategy was updated to _true_, so the user would see that strategy exactly once, no matter whether they actually made a change.  Now, the **hideFixItStrategy** flag is updated to _true_ only if the user actually makes a change.  That is, if the user sees the _Rent_ strategy, taps on the _Edit_ button, opens the _Add/Edit_ screen and taps the _Save_ button.  The tap on the _Save_ button triggers the changes.

- **_Formatting Changes_**:  See the screenshots below.
     - "Green" weeks (when the user has a positive week-ending balance) have a white background.  This includes transactions in the detail section below the calendar.  These transactions are bordered in _light gray_.
     - In "Red" weeks (when the user has a negative week-ending balance), the background is a light red and the numbers are bolded.  Those transactions are bordered in _dark red_.
     - When a "Green" week is selected, there is a black border around it.
     - When a "Red" week is selected, the background is _darker red_, the numerals are _white_ and _bold_ and there is a _black_ border around it.

## How to test this PR

1. Open app and clear all caches.
2. Add $0 _Starting Balance_.
3. In the same week, add the following expenses:
    - $500 Rent
     - $80 Electricity
     - $60 Eating Out
4. In the same week, add _Job Income_ of $400, every two weeks on Friday.
5.  Review the formatting and see that it matches the screenshots below.
6.  Select the _Red_ Week that includes the _Rent_.
7.  Tap the _Fix-it button.
8.  Find the strategy for _Rent_ and tap _Edit Rent_.
9.  When the _Add/Edit_ screen opens, tap the _Calendar_ icon at the bottom to go back to the calendar.
10. Select the _Red_ Week that includes the _Rent_, again.
11.  Tap the _Fix-it button, again.
12.  You should still see a strategy for _Rent_.  Tap _Edit Rent_.
13.  This time make a change to the rent transaction and tap _Save_.
14.  Select the _Red_ Week that includes the _Rent_, again.
15.  Tap the _Fix-it button, again.
16.  You should, no longer, see the _Rent_ strategy.


## Screenshots
<p>
<img width="150" alt="Screen Shot 2020-09-01 at 9 31 54 AM" src="https://user-images.githubusercontent.com/34319929/91859102-09811680-ec38-11ea-8d36-389fbc9f9bbf.png">
<img width="150" alt="Screen Shot 2020-09-01 at 9 31 42 AM" src="https://user-images.githubusercontent.com/34319929/91859104-0a19ad00-ec38-11ea-9236-1d175663a71d.png">
</p>
