### PR TITLE
mm/final draft revisions

### DIFF
--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/css/components/calendar.less
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/css/components/calendar.less
@@ -15,7 +15,7 @@
 @breakpointHiDPI: 1.5dppx;
 @symbolSize: 24px;
 @currentWeekBorder: 2px solid @inactiveMonthColor;
-@selectedWeekBorder: 3px solid @selectedMonthColor;
+@selectedWeekBorder: 2px solid @selectedMonthColor;
 
 .calendar {
   display: flex;
@@ -170,7 +170,6 @@
   }
 
   &__day-label {
-    font-weight: bold;
     color: @text;
   }
 

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/stores/strategies-store.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/stores/strategies-store.js
@@ -186,9 +186,7 @@ class StrategiesStore {
       }
     }
 
-    let reversedList = [...list].reverse();
-
-    return compact(reversedList).filter((item) => {
+    return compact(list).filter((item) => {
       if (strategyIDs.has(item.id)) return false;
       strategyIDs.add(item.id);
       this.logger.debug('Strategy IDs set: %O', strategyIDs);

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/calendar/index/details.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/calendar/index/details.js
@@ -131,7 +131,7 @@ const endBalanceClasses = clsx('calendar-details__ending-balance', uiStore.weekH
       {uiStore.weekHasPositiveBalance && (
         <div className={endBalanceClasses}>
           <Notification
-            message="You are going to be in the green!"
+            message="You're in the green this week!"
             variant="savings"
             actionLink={
               <Link to={`/calendar/add/expense/emergencySavings/new`} className="m-notification_save-button">
@@ -149,7 +149,7 @@ const endBalanceClasses = clsx('calendar-details__ending-balance', uiStore.weekH
       {uiStore.weekHasNegativeBalance && (
         <div className={endBalanceClasses}>
           <Notification
-            message="You are going to be in the red!"
+            message="You're in the red this week'!"
             variant="error"
             actionLink={
 

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/strategies/fix-it/index.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/strategies/fix-it/index.js
@@ -100,8 +100,7 @@ function FixItStrategies() {
                         copy={narrativeCopy.step3} />
       )}
       <header className="strategies-header">
-       
-        {strategies.fixItResults.length ? (
+    
           <div className="strategy-cards">
             <h2 className="strategies-header__week-range">Week of {uiStore.weekRangeText}</h2>
             <CardGroup columns={2}>
@@ -136,11 +135,6 @@ function FixItStrategies() {
               </div>
             </CardGroup>
           </div>
-        ) : (
-            <p>
-              <em>There are no strategy recommendations for this week</em>
-            </p>
-          )}
       </header>
       <h2 className="strategies-header__title">Fix-It Strategies</h2>
       <div>{strategies.fixItResults.length > 0 && <StrategyCards results={strategies.fixItResults} />}</div>

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/strategies/index.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/strategies/index.js
@@ -2,7 +2,6 @@ import { observer } from 'mobx-react';
 import { useStore } from '../../stores';
 import { useScrollToTop } from '../../components/scroll-to-top';
 import { CardGroup, Card } from '../../components/card';
-import { ButtonLink } from '../../components/button';
 
 const StrategyCards = ({ results }) => (
   <main className="strategy-cards">


### PR DESCRIPTION
Final revisions to the app per the client are as follows:

#### Changes
- unbold days of week
- reduce to 2pt border of week-selected
- change copy line on Fix-It and Save it to "You're in the green (red) this week"
- take out "There are no strategies for this week" line
- move strategies "Tight week" and "Covid" to the bottom of the stack

## How to Test this PR
1. Open app and clear all caches.
2. Add $0 _Starting Balance_.
3. In the same week, add the following expenses:
     - $300 Car Maintenance
     - $100 Groceries
4. Tap the _Strategies_ icon at the bottom.  The list of strategies should have the _Covid-19_ and _Tips for a Tight Week_ at the bottom.
5. In the same week, add _Job Income_ of $400, every two weeks on Friday.
6.  Select a _Red_ week.  The copy in the transaction header should match the screenshot below.
7. Select a _Green_ week.  The copy in the transaction header should match the screenshot below.
8.  Tap the _Fix-it button.
9.  The screen should look like the last screen below.



## Screenshots
<p>
<img height="300" alt="Screen Shot 2020-09-03 at 1 38 20 PM" src="https://user-images.githubusercontent.com/34319929/92149875-9b318500-edec-11ea-87dc-4f15a246422e.png">
<img height="300" alt="Screen Shot 2020-09-03 at 1 39 31 PM" src="https://user-images.githubusercontent.com/34319929/92149870-9a98ee80-edec-11ea-9b10-ce24773e1c59.png">
<img height="300" alt="Screen Shot 2020-09-03 at 1 38 49 PM" src="https://user-images.githubusercontent.com/34319929/92149872-9a98ee80-edec-11ea-866f-d7f1dad6a0c3.png">
<img height="300" alt="Screen Shot 2020-09-03 at 2 08 21 PM" src="https://user-images.githubusercontent.com/34319929/92151344-f6fd0d80-edee-11ea-8127-95575abfed8f.png">
</p>
